### PR TITLE
Added an option handler to support explicitly set booleans, i.e. '-myOpt false' and '-myOpt true' rather than '-myOpt' for true and omitting the option for false

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/ExplicitBooleanOptionHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ExplicitBooleanOptionHandler.java
@@ -1,0 +1,64 @@
+package org.kohsuke.args4j.spi;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+
+/**
+ * Boolean {@link OptionHandler} that (unlike the standard {@link BooleanOptionHandler}
+ * allows values to be set to false explicitly (using e.g. '-myOpt false') rather
+ * than only returning false when the option is <em>omitted</em>.
+ */
+public class ExplicitBooleanOptionHandler extends OptionHandler<Boolean> {
+    // same values as BooleanOptionHandler
+    private static final Map<String, Boolean> ACCEPTABLE_VALUES;
+    
+    static {
+        // I like the trick in BooleanOptionHandler but find this explicit map more readable
+        ACCEPTABLE_VALUES = new HashMap<String, Boolean>();
+        ACCEPTABLE_VALUES.put("true", TRUE);
+        ACCEPTABLE_VALUES.put("on", TRUE);
+        ACCEPTABLE_VALUES.put("yes", TRUE);
+        ACCEPTABLE_VALUES.put("1", TRUE);
+        ACCEPTABLE_VALUES.put("false", FALSE);
+        ACCEPTABLE_VALUES.put("off", FALSE);
+        ACCEPTABLE_VALUES.put("no", FALSE);
+        ACCEPTABLE_VALUES.put("0", FALSE);
+    }
+        
+    public ExplicitBooleanOptionHandler(CmdLineParser parser,
+            OptionDef option, Setter<? super Boolean> setter) {
+        super(parser, option, setter);
+    }
+
+    @Override
+    public int parseArguments(Parameters params) throws CmdLineException {
+        // end of arg list or next arg is another option
+        if ((params.size() == 0) || params.getParameter(0).startsWith("-")) {
+            setter.addValue(TRUE);
+            return 0;
+        } else {
+            setter.addValue(getBoolean(params.getParameter(0)));
+            return 1;
+        }
+    }
+
+    private Boolean getBoolean(String parameter) throws CmdLineException {
+        String valueStr = parameter.toLowerCase();
+        if (!ACCEPTABLE_VALUES.containsKey(valueStr)) {
+            throw new CmdLineException(owner, Messages.ILLEGAL_BOOLEAN.format(valueStr));
+        }
+        return ACCEPTABLE_VALUES.get(valueStr);
+    }
+
+    @Override
+    public String getDefaultMetaVariable() {
+        return "[VAL]";
+    }
+}

--- a/args4j/test/org/kohsuke/args4j/ExplicitBooleanArgumentTest.java
+++ b/args4j/test/org/kohsuke/args4j/ExplicitBooleanArgumentTest.java
@@ -1,0 +1,101 @@
+package org.kohsuke.args4j;
+
+import org.kohsuke.args4j.ExplicitBooleanArgumentTest.BooleanArgumentHolder;
+import org.kohsuke.args4j.spi.ExplicitBooleanOptionHandler;
+
+public class ExplicitBooleanArgumentTest extends Args4JTestBase<BooleanArgumentHolder> {
+
+    public static class BooleanArgumentHolder {
+        @Argument(index = 0, handler = ExplicitBooleanOptionHandler.class, usage = "Set a boolean value")
+        boolean booleanArg;
+    }
+
+    @Override
+    public BooleanArgumentHolder getTestObject() {
+        return new BooleanArgumentHolder();
+    }
+
+    public void testSetBooleanTrue() throws CmdLineException {
+        args = new String[] { "true" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanArg);
+    }
+
+    public void testSetBooleanOn() throws CmdLineException {
+        args = new String[] { "on" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanArg);
+    }
+    
+    public void testSetBooleanYes() throws CmdLineException {
+        args = new String[] { "yes" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanArg);
+    }
+
+    public void testSetBooleanTrueCaseInsensitive() throws CmdLineException {
+        args = new String[] { "tRuE" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanArg);
+    }
+    
+    public void testSetBoolean1() throws CmdLineException {
+        args = new String[] { "1" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanArg);
+    }
+
+    public void testSetBooleanFalse() throws CmdLineException {
+        args = new String[] { "false" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanArg);
+    }
+
+    public void testSetBooleanOff() throws CmdLineException {
+        args = new String[] { "off" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanArg);
+    }
+    
+    public void testSetBooleanNo() throws CmdLineException {
+        args = new String[] { "no" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanArg);
+    }
+
+    public void testSetBoolean0() throws CmdLineException {
+        args = new String[] { "0" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanArg);
+    }
+
+    public void testSetBooleanFalseCaseInsensitive() throws CmdLineException {
+        args = new String[] { "FaLsE" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanArg);
+    }
+    
+    public void testSetBooleanNoValueIsFalse() throws CmdLineException {
+        args = new String[0];
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanArg);
+    }
+
+    public void testIllegalBoolean() {
+        args = new String[] { "ILLEGAL_BOOLEAN" };
+        try {
+            parser.parseArgument(args);
+            fail("Can't set ILLEGAL_BOOLEAN as value.");
+        } catch (CmdLineException expected) {}
+    }
+
+    public void testUsage() {
+        args = new String[] { "-wrong" };
+        try {
+            parser.parseArgument(args);
+        } catch (CmdLineException e) {
+            assertUsageContains("Usage message should contain '[VAL]'", "[VAL]");
+        }
+    }
+
+}

--- a/args4j/test/org/kohsuke/args4j/ExplicitBooleanOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/ExplicitBooleanOptionTest.java
@@ -1,0 +1,110 @@
+package org.kohsuke.args4j;
+
+import org.kohsuke.args4j.ExplicitBooleanOptionTest.BooleanOptionHolder;
+import org.kohsuke.args4j.spi.ExplicitBooleanOptionHandler;
+
+public class ExplicitBooleanOptionTest extends Args4JTestBase<BooleanOptionHolder> {
+
+    public static class BooleanOptionHolder {
+        @Option(name = "-booleanOpt", handler = ExplicitBooleanOptionHandler.class, usage = "Set a boolean value")
+        boolean booleanOpt;
+        
+        @Option(name = "-nextArg")
+        boolean nextArg;
+    }
+
+    @Override
+    public BooleanOptionHolder getTestObject() {
+        return new BooleanOptionHolder();
+    }
+
+    public void testSetBooleanTrue() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "true" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanOpt);
+    }
+
+    public void testSetBooleanOn() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "on" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanOpt);
+    }
+    
+    public void testSetBooleanYes() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "yes" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanOpt);
+    }
+
+    public void testSetBooleanTrueCaseInsensitive() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "tRuE" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanOpt);
+    }
+    
+    public void testSetBoolean1() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "1" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanOpt);
+    }
+
+    public void testSetBooleanFalse() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "false" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanOpt);
+    }
+
+    public void testSetBooleanOff() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "off" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanOpt);
+    }
+    
+    public void testSetBooleanNo() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "no" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanOpt);
+    }
+
+    public void testSetBoolean0() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "0" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanOpt);
+    }
+
+    public void testSetBooleanFalseCaseInsensitive() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "FaLsE" };
+        parser.parseArgument(args);
+        assertFalse(testObject.booleanOpt);
+    }
+    
+    public void testSetBooleanLastArgIsTrue() throws CmdLineException {
+        args = new String[] { "-booleanOpt" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanOpt);
+    }
+
+    public void testSetBooleanWithoutParamIsTrue() throws CmdLineException {
+        args = new String[] { "-booleanOpt", "-nextArg" };
+        parser.parseArgument(args);
+        assertTrue(testObject.booleanOpt);
+    }
+    
+    public void testIllegalBoolean() {
+        args = new String[] { "-booleanOpt", "ILLEGAL_BOOLEAN" };
+        try {
+            parser.parseArgument(args);
+            fail("Can't set ILLEGAL_BOOLEAN as value.");
+        } catch (CmdLineException expected) {}
+    }
+
+    public void testUsage() {
+        args = new String[] { "-wrong" };
+        try {
+            parser.parseArgument(args);
+        } catch (CmdLineException e) {
+            assertUsageContains("Usage message should contain '[VAL]'", "[VAL]");
+        }
+    }
+
+}


### PR DESCRIPTION
This is useful especially if you want to have a required boolean value that can be false. The standard boolean is only false when omitted.
