### PR TITLE
Adding support for '-' in enums.

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/EnumOptionHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/EnumOptionHandler.java
@@ -20,7 +20,7 @@ public class EnumOptionHandler<T extends Enum<T>> extends OptionHandler<T> {
 
     @Override
     public int parseArguments(Parameters params) throws CmdLineException {
-        String s = params.getParameter(0);
+        String s = params.getParameter(0).replaceAll("-", "_");
         T value = null;
         for( T o : enumType.getEnumConstants() )
             if(o.name().equalsIgnoreCase(s)) {


### PR DESCRIPTION
Adding more convinient way to pass enum through command line. 
So you can use: `-opt some-enum-option` for

``` java
public enum TestEnum {
  SOME_ENUM_OPTION,
  ANOTHER_ENUM_OPTION;
}
```

which would be equal to `-opt some_enum_option`.
