### PR TITLE
Generate OSGi metadata in JAR files

### DIFF
--- a/args4j-tools/pom.xml
+++ b/args4j-tools/pom.xml
@@ -11,6 +11,8 @@
   <name>args4j-tools</name>
   <description>development-time tool for generating additional artifacits</description>
 
+  <packaging>bundle</packaging>
+
   <properties>
     <mainClass>org.kohsuke.args4j.apt.Main</mainClass>
   </properties>

--- a/args4j/pom.xml
+++ b/args4j/pom.xml
@@ -8,6 +8,8 @@
   </parent>
   <artifactId>args4j</artifactId>
   <name>args4j</name>
+
+  <packaging>bundle</packaging>
   
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,16 @@
         <artifactId>maven-site-plugin</artifactId>
         <version>3.0-beta-3</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.kohsuke.${pom.artifactId}</Bundle-SymbolicName>
+          </instructions>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The first commit here is a minor fix that I noticed while working on this.  The second turns args4j.jar and args4j-tools.jar into OSGi bundles using the Felix Maven plugin.
