### PR TITLE
Introduce hidden options

### DIFF
--- a/args4j/examples/SampleMain.java
+++ b/args4j/examples/SampleMain.java
@@ -28,6 +28,9 @@ public class SampleMain {
     @Option(name="-str")        // no usage
     private String str = "(default value)";
 
+    @Option(name="-hidden-str2",hidden=true,usage="hidden option")
+    private String hiddenStr2 = "(default value)";
+
     @Option(name="-n",usage="repeat <n> times\nusage can have new lines in it and also it can be verrrrrrrrrrrrrrrrrry long")
     private int num = -1;
 

--- a/args4j/src/org/kohsuke/args4j/Argument.java
+++ b/args4j/src/org/kohsuke/args4j/Argument.java
@@ -39,6 +39,11 @@ public @interface Argument {
     boolean required() default false;
 
     /**
+     * See {@link Option#hidden()}.
+     */
+    boolean hidden() default false;
+
+    /**
      * See {@link Option#handler()}.
      */
     Class<? extends OptionHandler> handler() default OptionHandler.class;

--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -226,6 +226,7 @@ public class CmdLineParser {
         for (OptionHandler h : options) {
             OptionDef option = h.option;
             if(option.usage().length()==0)  continue;   // ignore
+            if(option.hidden())             continue;
             if(!mode.print(option))         continue;
 
             buf.append(' ');
@@ -286,7 +287,9 @@ public class CmdLineParser {
      */
     private void printOption(PrintWriter out, OptionHandler handler, int len, ResourceBundle rb) {
     	// Hiding options without usage information
-    	if (handler.option.usage() == null || handler.option.usage().length() == 0) {
+    	if (handler.option.usage() == null ||
+            handler.option.usage().length() == 0 ||
+            handler.option.hidden()) {
     		return;
     	}
 

--- a/args4j/src/org/kohsuke/args4j/NamedOptionDef.java
+++ b/args4j/src/org/kohsuke/args4j/NamedOptionDef.java
@@ -16,7 +16,7 @@ public final class NamedOptionDef extends OptionDef {
     }
 
     public NamedOptionDef(Option o) {
-    	super(o.usage(),o.metaVar(),o.required(),o.handler(),false);
+    	super(o.usage(),o.metaVar(),o.required(),o.hidden(),o.handler(),false);
 
     	this.name = o.name();
     	this.aliases = o.aliases();

--- a/args4j/src/org/kohsuke/args4j/Option.java
+++ b/args4j/src/org/kohsuke/args4j/Option.java
@@ -134,6 +134,14 @@ public @interface Option {
     boolean required() default false;
 
     /**
+     * Specify that the option is hidden.
+     *
+     * <p>
+     * Hidden options do not show up in usage.
+     */
+    boolean hidden() default false;
+
+    /**
      * Specify the {@link OptionHandler} that processes the command line arguments.
      *
      * <p>

--- a/args4j/src/org/kohsuke/args4j/OptionDef.java
+++ b/args4j/src/org/kohsuke/args4j/OptionDef.java
@@ -12,18 +12,21 @@ public class OptionDef {
 	private final String usage;
 	private final String metaVar;
 	private final boolean required;
+	private final boolean hidden;
 	private final boolean multiValued;
 	private final Class<? extends OptionHandler> handler;
 
 	public OptionDef(Argument a, boolean forceMultiValued) {
-		this(a.usage(), a.metaVar(), a.required(), a.handler(), a.multiValued() || forceMultiValued);
+		this(a.usage(), a.metaVar(), a.required(), a.hidden(), a.handler(), a.multiValued() || forceMultiValued);
 	}
 
 	protected OptionDef(String usage, String metaVar, boolean required,
-			Class<? extends OptionHandler> handler, boolean multiValued) {
+			boolean hidden, Class<? extends OptionHandler> handler,
+			boolean multiValued) {
 		this.usage = usage;
 		this.metaVar = metaVar;
 		this.required = required;
+		this.hidden = hidden;
 		this.handler = handler;
 		this.multiValued = multiValued;
 	}
@@ -38,6 +41,10 @@ public class OptionDef {
 
 	public boolean required() {
 		return required;
+	}
+
+	public boolean hidden() {
+		return hidden;
 	}
 
 	public Class<? extends OptionHandler> handler() {

--- a/args4j/src/org/kohsuke/args4j/spi/AnnotationImpl.java
+++ b/args4j/src/org/kohsuke/args4j/spi/AnnotationImpl.java
@@ -26,6 +26,7 @@ public abstract class AnnotationImpl implements Annotation {
 		metaVar = ce.metavar != null ? ce.metavar : "";
 		multiValued = ce.multiValued;
 		required = ce.required;
+		hidden = ce.hidden;
 		usage = ce.usage != null ? ce.usage : "";
 	}
 
@@ -48,6 +49,10 @@ public abstract class AnnotationImpl implements Annotation {
 	public boolean required;
 	public boolean required() {
 		return required;
+	}
+	public boolean hidden;
+	public boolean hidden() {
+		return hidden;
 	}
 	public String usage;
 	public String usage() {

--- a/args4j/src/org/kohsuke/args4j/spi/ConfigElement.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ConfigElement.java
@@ -15,6 +15,7 @@ public class ConfigElement {
 	public String[] aliases = {};
 	public boolean multiValued = false;
 	public boolean required = false;
+	public boolean hidden = false;
 	/**
 	 * Ensures that only a field XOR a method is set.
 	 * @return

--- a/args4j/test/org/kohsuke/args4j/HiddenOption.java
+++ b/args4j/test/org/kohsuke/args4j/HiddenOption.java
@@ -1,0 +1,8 @@
+package org.kohsuke.args4j;
+
+import org.kohsuke.args4j.Option;
+
+public class HiddenOption {
+    @Option(name="-str",usage="set a string",metaVar="METAVAR",hidden=true)
+    public String str;
+}

--- a/args4j/test/org/kohsuke/args4j/HiddenOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/HiddenOptionTest.java
@@ -1,0 +1,24 @@
+package org.kohsuke.args4j;
+
+public class HiddenOptionTest extends Args4JTestBase<HiddenOption> {
+    @Override
+    public HiddenOption getTestObject() {
+        return new HiddenOption();
+    }
+
+    public void testSettingUsage() {
+        args = new String[]{"-wrong-usage"};
+        try {
+            parser.parseArgument(args);
+            fail("Doesnt detect wrong parameters.");
+        } catch (CmdLineException e) {
+            String expectedError = "\"-wrong-usage\" is not a valid option";
+            String expectedUsage = "";
+            String[] usageLines = getUsageMessage();
+            String errorMessage = e.getMessage();
+            assertUsageLength(1);
+            assertTrue("Got wrong error message", errorMessage.startsWith(expectedError));
+            assertEquals("Got wrong usage message", expectedUsage, usageLines[0]);
+        }
+    }
+}


### PR DESCRIPTION
Developers often use hidden options for internal purposes which they
do not wish to expose to end-users.
