### PR TITLE
Fix ARGS4J-25 - support args like "-coll val1 val2 -coll val3"

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
@@ -62,14 +62,26 @@ final class ArrayFieldSetter implements Setter {
 
     private void doAddValue(Object bean, Object value) throws IllegalAccessException {
         Object ary = f.get(bean);
-        if(ary==null) {
-            ary = Array.newInstance(getType(),1);
-            Array.set(ary,0,value);
+        if (ary == null) {
+            if (value.getClass().isArray()) {
+                ary = Array.newInstance(getType(), Array.getLength(value));
+                System.arraycopy(value, 0, ary, 0, Array.getLength(value));
+            } else {
+                ary = Array.newInstance(getType(), 1);
+                Array.set(ary, 0, value);
+            }
         } else {
             int len = Array.getLength(ary);
-            Object newAry = Array.newInstance(ary.getClass().getComponentType(), len +1);
-            System.arraycopy(ary,0,newAry,0,len);
-            Array.set(newAry,len,value);
+            Object newAry;
+            if(value.getClass().isArray()) {
+                newAry = Array.newInstance(ary.getClass().getComponentType(), len + Array.getLength(value));
+                System.arraycopy(ary, 0, newAry, 0, len);
+                System.arraycopy(value, 0, newAry, len, Array.getLength(value));
+            } else {
+                newAry = Array.newInstance(ary.getClass().getComponentType(), len + 1);
+                System.arraycopy(ary, 0, newAry, 0, len);
+                Array.set(newAry, len, value);
+            }
             ary = newAry;
         }
 

--- a/args4j/test/org/kohsuke/args4j/MultivaluedTest.java
+++ b/args4j/test/org/kohsuke/args4j/MultivaluedTest.java
@@ -1,5 +1,7 @@
 package org.kohsuke.args4j;
 
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
 import java.util.List;
 
 public class MultivaluedTest extends Args4JTestBase<MultivaluedTest> {
@@ -11,9 +13,12 @@ public class MultivaluedTest extends Args4JTestBase<MultivaluedTest> {
     
     @Option(name="-string")
     String string;
-    
+
     @Option(name="-array")
     String[] array;
+
+    @Option(name="-multivalued-array", handler = StringArrayOptionHandler.class)
+    String[] multiValuedArray;
 
     // The JUnit part of this class as tester.
 
@@ -54,5 +59,15 @@ public class MultivaluedTest extends Args4JTestBase<MultivaluedTest> {
         assertEquals("one",array[0]);
         assertEquals("two",array[1]);
         assertEquals("three",array[2]);
+    }
+
+    public void testOnMultiValuedArray() throws Exception {
+        // The 'command line invocation'.
+        parser.parseArgument("-multivalued-array","one", "two","-multivalued-array","three");
+        // Check the results.
+        assertEquals("Should got three values", 3, multiValuedArray.length);
+        assertEquals("one",multiValuedArray[0]);
+        assertEquals("two",multiValuedArray[1]);
+        assertEquals("three",multiValuedArray[2]);
     }
 }


### PR DESCRIPTION
Fix [ARGS4J-25](https://java.net/jira/browse/ARGS4J-25) - support args like `-coll val1 val2 -coll val3` with `@Collection(name="-coll", handler = StringArrayOptionHandler.class, …)`

Fix: 

```
java.lang.IllegalArgumentException: array element type mismatch
at java.lang.reflect.Array.set(Native Method)
at org.kohsuke.args4j.spi.ArrayFieldSetter.doAddValue(ArrayFieldSetter.java:67)
at org.kohsuke.args4j.spi.ArrayFieldSetter.addValue(ArrayFieldSetter.java:56)
at org.kohsuke.args4j.spi.StringArrayOptionHandler.parseArguments(StringArrayOptionHandler.java:75)
at org.kohsuke.args4j.CmdLineParser.parseArgument(CmdLineParser.java:440)
```
