### PR TITLE
Make Messages enumeration public to ease extension of OptionHandlers

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/Messages.java
+++ b/args4j/src/org/kohsuke/args4j/spi/Messages.java
@@ -6,7 +6,7 @@ import java.util.ResourceBundle;
 /**
  * @author Kohsuke Kawaguchi
  */
-enum Messages {
+public enum Messages {
     ILLEGAL_OPERAND,
     ILLEGAL_CHAR,
     ILLEGAL_BOOLEAN,


### PR DESCRIPTION
Make Messages enumeration public to ease extension of OptionHandlers creating other implementation in different packages than `org.kohsuke.args4j.spi`.
