### PR TITLE
added support for args in format -argname=argvalue

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -430,6 +430,15 @@ public class CmdLineParser {
         public int size() {
             return args.length-pos;
         }
+
+        public void splitToken(){
+            if(pos < args.length && pos >= 0){
+                int idx = args[pos].indexOf("=");
+                if(idx > 0){
+                    args[pos] = args[pos].substring(idx + 1);
+                }
+            }
+        }
     }
 
     private String getOptionName() {
@@ -472,7 +481,11 @@ public class CmdLineParser {
                 }
 
                 // known option; skip its name
-                cmdLine.proceed(1);
+                if (isKeyValuePair) {
+                    cmdLine.splitToken();
+                } else {
+                    cmdLine.proceed(1);
+                }
             } else {
             	if (argIndex >= arguments.size()) {
             		Messages msg = arguments.size() == 0 ? Messages.NO_ARGUMENT_ALLOWED : Messages.TOO_MANY_ARGUMENTS;
@@ -565,7 +578,7 @@ public class CmdLineParser {
 	private Map<String,OptionHandler> filter(List<OptionHandler> opt, String keyFilter) {
 		Map<String,OptionHandler> rv = new TreeMap<String,OptionHandler>();
 		for (OptionHandler h : opt) {
-			if (opt.toString().startsWith(keyFilter)) rv.put(opt.toString(), h);
+			if (h.option.toString().startsWith(keyFilter)) rv.put(h.option.toString(), h);
 		}
 		return rv;
 	}

--- a/args4j/test/org/kohsuke/args4j/KeyValue.java
+++ b/args4j/test/org/kohsuke/args4j/KeyValue.java
@@ -1,0 +1,12 @@
+package org.kohsuke.args4j;
+
+@SuppressWarnings("unused")
+public class KeyValue {
+
+  @Option(name="-string")
+  public String _string;
+
+  @Option(name="-double")
+  public double _double;
+
+}

--- a/args4j/test/org/kohsuke/args4j/KeyValueTest.java
+++ b/args4j/test/org/kohsuke/args4j/KeyValueTest.java
@@ -1,0 +1,22 @@
+package org.kohsuke.args4j;
+
+public class KeyValueTest extends Args4JTestBase<KeyValue> {
+
+  @Override
+  public KeyValue getTestObject() {
+    return new KeyValue();
+  }
+
+  public void testDouble() throws CmdLineException {
+    args = new String[]{"-double=42.54"};
+    parser.parseArgument(args);
+    assertEquals(42.54, testObject._double, 0);
+  }
+
+  public void testChar() throws CmdLineException {
+    args = new String[]{"-string=stringValue"};
+    parser.parseArgument(args);
+    assertEquals("stringValue", testObject._string);
+  }
+
+}


### PR DESCRIPTION
Hi Kohsuke, 

Args4j should definitely have the following feature (which present in JCommander): 
support for args in format -argname=argvalue 

I change a little CmdLineParser.java and added some unit tests to give examples
