### PR TITLE
Fix incorrect parsing of Key=Value pairs in CmdLineParser.filter(List<OptionHandler> opt, String keyFilter)

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -580,13 +580,24 @@ public class CmdLineParser {
 	}
 
 
-	private Map<String,OptionHandler> filter(List<OptionHandler> opt, String keyFilter) {
-		Map<String,OptionHandler> rv = new TreeMap<String,OptionHandler>();
-		for (OptionHandler h : opt) {
-			if (h.option.toString().startsWith(keyFilter)) rv.put(h.option.toString(), h);
-		}
-		return rv;
-	}
+  private Map<String,OptionHandler> filter(List<OptionHandler> opt, String keyFilter) {
+    Map<String,OptionHandler> rv = new TreeMap<String,OptionHandler>();
+    for (OptionHandler h : opt) {
+      NamedOptionDef option = (NamedOptionDef)h.option;
+      String prefix = "";
+      for (String alias : option.aliases()) {
+        if (keyFilter.startsWith(alias)) {
+          prefix = keyFilter;
+          break;
+        }
+      }
+      if (option.name().startsWith(keyFilter)){
+        prefix = keyFilter;
+      }
+      rv.put(prefix, h);
+    }
+    return rv;
+  }
 
 
     /**

--- a/args4j/test/org/kohsuke/args4j/KeyValue.java
+++ b/args4j/test/org/kohsuke/args4j/KeyValue.java
@@ -3,10 +3,10 @@ package org.kohsuke.args4j;
 @SuppressWarnings("unused")
 public class KeyValue {
 
-  @Option(name="-string")
+  @Option(name="-s", aliases="--string")
   public String _string;
 
-  @Option(name="-double")
+  @Option(name="-d", aliases="--double")
   public double _double;
 
 }

--- a/args4j/test/org/kohsuke/args4j/KeyValueTest.java
+++ b/args4j/test/org/kohsuke/args4j/KeyValueTest.java
@@ -8,13 +8,26 @@ public class KeyValueTest extends Args4JTestBase<KeyValue> {
   }
 
   public void testDouble() throws CmdLineException {
-    args = new String[]{"-double=42.54"};
+    args = new String[]{"--double=42.54"};
     parser.parseArgument(args);
     assertEquals(42.54, testObject._double, 0);
   }
 
+  public void testDoubleShort() throws CmdLineException {
+    args = new String[]{"-d=42.54"};
+    parser.parseArgument(args);
+    assertEquals(42.54, testObject._double, 0);
+  }
+
+
   public void testChar() throws CmdLineException {
-    args = new String[]{"-string=stringValue"};
+    args = new String[]{"--string=stringValue"};
+    parser.parseArgument(args);
+    assertEquals("stringValue", testObject._string);
+  }
+
+  public void testCharShort() throws CmdLineException {
+    args = new String[]{"-s=stringValue"};
     parser.parseArgument(args);
     assertEquals("stringValue", testObject._string);
   }


### PR DESCRIPTION
Currently CmdLineParser.filter(List<OptionHandler> opt, String keyFilter) calls h.option.toString() which results in failures for parameters that have aliases. This patch fixes the problem. 
