### PR TITLE
Remove the unused dependency on Ant

### DIFF
--- a/args4j-tools/pom.xml
+++ b/args4j-tools/pom.xml
@@ -67,11 +67,6 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>ant</groupId>
-      <artifactId>ant</artifactId>
-      <version>1.5</version>
-    </dependency>
-    <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
args4j-tools depends on Ant but the code doesn't use it. This dependency could be removed.
