### PR TITLE
Rename the identifiers '_' to avoid a compiler warning with Java 8

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
@@ -49,7 +49,7 @@ final class ArrayFieldSetter implements Setter {
     public void addValue(Object value) {
         try {
             doAddValue(bean, value);
-        } catch (IllegalAccessException _) {
+        } catch (IllegalAccessException ex) {
             // try again
             f.setAccessible(true);
             try {

--- a/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
@@ -37,7 +37,7 @@ public final class FieldSetter implements Setter {
     public void addValue(Object value) {
         try {
             f.set(bean,value);
-        } catch (IllegalAccessException _) {
+        } catch (IllegalAccessException ex) {
             // try again
             f.setAccessible(true);
             try {
@@ -51,7 +51,7 @@ public final class FieldSetter implements Setter {
     public Object getValue() {
         try {
             return f.get(bean);
-        } catch (IllegalAccessException _) {
+        } catch (IllegalAccessException ex) {
             // try again
             f.setAccessible(true);
             try {

--- a/args4j/src/org/kohsuke/args4j/spi/MethodSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/MethodSetter.java
@@ -46,7 +46,7 @@ public final class MethodSetter implements Setter {
         try {
             try {
                 m.invoke(bean,value);
-            } catch (IllegalAccessException _) {
+            } catch (IllegalAccessException ex) {
                 // try again
                 m.setAccessible(true);
                 try {

--- a/args4j/src/org/kohsuke/args4j/spi/MultiValueFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/MultiValueFieldSetter.java
@@ -53,7 +53,7 @@ final class MultiValueFieldSetter implements Setter {
     public void addValue(Object value) {
         try {
             doAddValue(bean, value);
-        } catch (IllegalAccessException _) {
+        } catch (IllegalAccessException ex) {
             // try again
             f.setAccessible(true);
             try {


### PR DESCRIPTION
Hi,

Using '_' as the name of an identifier now generates a warning with Java 8 (it may have a special meaning in a future version). Here is a simple patch fixing it.
