### PR TITLE
#41 Possibility to exclude Options if other option is present

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -527,6 +527,14 @@ public class CmdLineParser {
                         .format(handler.option.toString(), Arrays.toString(((NamedOptionDef)handler.option).depends())));
             }
         }
+        
+        //make sure that all forbids arguments are not present
+        for(OptionHandler handler : present) {
+            if(handler.option instanceof NamedOptionDef && !isHandlerForbidHisOptions((NamedOptionDef)handler.option, present)) {
+                throw new CmdLineException(this, Messages.FORBID_OPTION_SHOWING
+                        .format(handler.option.toString(), Arrays.toString(((NamedOptionDef)handler.option).forbids())));
+            }
+        }
     }
 
     /**
@@ -544,6 +552,21 @@ public class CmdLineParser {
         return true;
     }
 
+    /**
+     * @param option
+     * @param present
+     * @return {@code true} if all options forbid by {@code option} are not present, {@code false} otherwise
+     */
+    private boolean isHandlerForbidHisOptions(NamedOptionDef option, Set<OptionHandler> present) {
+        if (option.forbids() != null) {
+            for (String forbid : option.forbids()) {
+                if (present.contains(findOptionHandler(forbid)))
+                    return false;
+            }
+        }
+        return true;
+    }
+    
     private OptionHandler findOptionHandler(String name) {
 		OptionHandler handler = findOptionByName(name);
 		if (handler==null) {

--- a/args4j/src/org/kohsuke/args4j/Messages.java
+++ b/args4j/src/org/kohsuke/args4j/Messages.java
@@ -19,7 +19,8 @@ enum Messages {
     UNKNOWN_HANDLER,
     NO_OPTIONHANDLER,
     NO_CONSTRUCTOR_ON_HANDLER,
-    REQUIRES_OPTION_MISSING
+    REQUIRES_OPTION_MISSING,
+    FORBID_OPTION_SHOWING
     ;
 
     private static ResourceBundle rb;

--- a/args4j/src/org/kohsuke/args4j/Messages.properties
+++ b/args4j/src/org/kohsuke/args4j/Messages.properties
@@ -36,3 +36,6 @@ NO_CONSTRUCTOR_ON_HANDLER = \
 
 REQUIRES_OPTION_MISSING = \
     option "{0}" requires the option(s) {1}
+
+FORBID_OPTION_SHOWING = \
+    option "{0}" cannot be used with the option(s) {1}

--- a/args4j/src/org/kohsuke/args4j/NamedOptionDef.java
+++ b/args4j/src/org/kohsuke/args4j/NamedOptionDef.java
@@ -7,6 +7,7 @@ public final class NamedOptionDef extends OptionDef {
     private final String name;
 	private final String[] aliases;
     private final String[] depends;
+    private final String[] forbids;
     
     /**
      * @deprecated
@@ -22,6 +23,7 @@ public final class NamedOptionDef extends OptionDef {
     	this.name = o.name();
     	this.aliases = o.aliases();
         this.depends = o.depends();
+        this.forbids = o.forbids();
     }
 
     public String name() {
@@ -34,6 +36,10 @@ public final class NamedOptionDef extends OptionDef {
 
     public String[] depends() {
         return depends;
+    }
+
+    public String[] forbids() {
+        return forbids;
     }
     
     @Override

--- a/args4j/src/org/kohsuke/args4j/Option.java
+++ b/args4j/src/org/kohsuke/args4j/Option.java
@@ -200,4 +200,24 @@ public @interface Option {
      * </p>
      */
     String[] depends() default { };
+    
+    /**
+     * List of other options that this option forbids.
+     *
+     * <h3>Example</h3>
+     *
+     * <code><pre>
+     *  &#64;Option(name="-a")
+     *  int a;
+     *  //-h will forbid a if presented
+     *  &#64;Option(name="-h", forbids={"-a"}
+     *  boolean h;
+     * </pre></code>
+     *
+     * <p>
+     * At the end of {@link CmdLineParser#parseArgument(String...)},
+     * a {@link CmdLineException} will be thrown if options forbid other options
+     * </p>
+     */
+    String[] forbids() default { };    
 }

--- a/args4j/src/org/kohsuke/args4j/spi/OptionImpl.java
+++ b/args4j/src/org/kohsuke/args4j/spi/OptionImpl.java
@@ -21,4 +21,9 @@ public class OptionImpl extends AnnotationImpl implements Option {
     public String[] depends() {
         return depends;
     }
+    
+    public String[] forbids;
+    public String[] forbids() {
+        return depends;
+    }
 }

--- a/args4j/test/ExampleTest.java
+++ b/args4j/test/ExampleTest.java
@@ -23,9 +23,12 @@ public class ExampleTest extends TestCase {
     @Option(name = "-c", usage = "this is Z")
     InetAddress z;
 
+    @Option(name = "-h", usage = "this is H", forbids={"-b", "-c"})
+    boolean h;
+    
     public void testPrintExampleModeAll() {
         String s = new CmdLineParser(this).printExample(ExampleMode.ALL);
-        assertEquals(" -a N -b <output> -c <ip address>", s);
+        assertEquals(" -a N -b <output> -c <ip address> -h", s);
     }
 
     public void testPrintExampleModeRequired() {
@@ -57,6 +60,17 @@ public class ExampleTest extends TestCase {
                     + " required arg 'a' is missing");
         } catch (CmdLineException e) {
             assertEquals("Option \"-a\" is required", e.getMessage());
+        }
+    }
+    
+    public void testForbidArgs() throws Exception {
+        CmdLineParser parser = new CmdLineParser(this);
+        try {
+        	parser.parseArgument("-h", "-a", "2", "-b", "1");
+        	fail("Should have thrown an exception because"
+                    + " arg 'h' forbids 'b'");
+        } catch (CmdLineException e) {
+            assertEquals("option \"-h\" cannot be used with the option(s) [-b, -c]", e.getMessage());
         }
     }
 }

--- a/args4j/test/org/kohsuke/args4j/DependencyOptions.java
+++ b/args4j/test/org/kohsuke/args4j/DependencyOptions.java
@@ -21,4 +21,7 @@ public class DependencyOptions {
 
     @Option(name = "-d", depends ={"-b", "-c"})
     int z;
+    
+    @Option(name = "-h", forbids ={"-a", "-b"})
+    int o;
 }

--- a/args4j/test/org/kohsuke/args4j/DependencyOptionsTest.java
+++ b/args4j/test/org/kohsuke/args4j/DependencyOptionsTest.java
@@ -75,6 +75,17 @@ public class DependencyOptionsTest extends Args4JTestBase<DependencyOptions> {
         }
     }
 
+    public void testForbidFail() throws Exception {
+        args= new String[]{"-a", "5", "-b", "1", "-h", "5"};
+        try {
+            parser.parseArgument(args);
+            fail();
+        } catch (CmdLineException e) {
+            System.out.println(e.getMessage());
+            assertTrue(e.getMessage().contains("cannot be used with the option(s) [-a, -b]"));
+        }
+    }
+    
     public void testRecursive() throws Exception {
         args= new String[]{"-z","4" , "-y","3"};
         try {


### PR DESCRIPTION
Hi,

This is Mingtao. It's my first attempt in open source ... Seems unit-test and integration-test both passed.

Target on fixing the above scenario. Specifically for -h, which let -h possibly forbids other options.

---

I really have trouble to remove several files that I don't want to commit ...
.classpath
.gitignore
bin/META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
and those *.class files.
