### PR TITLE
print seperating colon in usage only for the first line

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -23,7 +23,6 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Logger;
-
 import org.kohsuke.args4j.spi.BooleanOptionHandler;
 import org.kohsuke.args4j.spi.ByteOptionHandler;
 import org.kohsuke.args4j.spi.CharOptionHandler;
@@ -380,7 +379,7 @@ public class CmdLineParser {
                 int lineLength;
                 String candidate = restOfLine.substring(0, maxLength);
                 int sp=candidate.lastIndexOf(' ');
-                if(sp>maxLength*3/4)    lineLength=sp;
+                if(sp>maxLength*3/5)    lineLength=sp;
                 else                    lineLength=maxLength;
                 rv.add(restOfLine.substring(0, lineLength));
                 restOfLine = restOfLine.substring(lineLength).trim();


### PR DESCRIPTION
... for better readability.

Fixes #54

New Output:

```
"xy" is not a valid value for "-e"
 -e (--environment) training, productio : application environment (default:
 n, testing, development, custom          development)
```
