### PR TITLE
The so-called @-syntax for file-based-option-passing

### DIFF
--- a/args4j/test/org/kohsuke/args4j/AtOption.java
+++ b/args4j/test/org/kohsuke/args4j/AtOption.java
@@ -1,0 +1,10 @@
+package org.kohsuke.args4j;
+
+@SuppressWarnings("unused")
+public class AtOption {
+    @Option(name="-string",usage="set a string")
+    public String str = "default";
+    
+    @Option(name="-noUsage")
+    public String noUsage;
+}

--- a/args4j/test/org/kohsuke/args4j/AtOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/AtOptionTest.java
@@ -1,0 +1,64 @@
+package org.kohsuke.args4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * Tests the AT sign that reads options from an external file.
+ * @author Stephan Fuhrmann
+ */
+public class AtOptionTest extends Args4JTestBase<AtOption> {
+    @Override
+    public AtOption getTestObject() {
+        return new AtOption();
+    }
+
+    public void testSimpleAt() throws IOException, CmdLineException {
+        
+        File tmp = File.createTempFile("atoption", null);
+        PrintWriter printWriter = new PrintWriter(tmp);
+        printWriter.println("-string\nfoo");
+        printWriter.close();
+        
+        args = new String[]{"@"+tmp.getAbsolutePath()};
+        parser.parseArgument(args);
+        
+        assertEquals("foo", testObject.str);
+        assertEquals(null, testObject.noUsage);
+        
+        tmp.delete();
+    }
+    
+    public void testAtAfterOpts() throws IOException, CmdLineException {
+        
+        File tmp = File.createTempFile("atoption", null);
+        PrintWriter printWriter = new PrintWriter(tmp);
+        printWriter.println("-string\nfoo");
+        printWriter.close();
+        
+        args = new String[]{"-noUsage","lala", "@"+tmp.getAbsolutePath()};
+        parser.parseArgument(args);
+        
+        assertEquals("foo", testObject.str);
+        assertEquals("lala", testObject.noUsage);
+        
+        tmp.delete();
+    }
+    
+    public void testAtBeforeOpts() throws IOException, CmdLineException {
+        
+        File tmp = File.createTempFile("atoption", null);
+        PrintWriter printWriter = new PrintWriter(tmp);
+        printWriter.println("-string\nfoo");
+        printWriter.close();
+        
+        args = new String[]{"@"+tmp.getAbsolutePath(), "-noUsage","lala"};
+        parser.parseArgument(args);
+        
+        assertEquals("foo", testObject.str);
+        assertEquals("lala", testObject.noUsage);
+        
+        tmp.delete();
+    }
+}


### PR DESCRIPTION
### At-syntax for fetching option values from files

This pull request brings the At-syntax from JCommander to args4j. The syntax is depicted here:

```
java Cmd @/tmp/opts
```

@/tmp/opts is a text file with the options separated by line breaks:

```
-key
value
-variable
value
```

The JCommander version can be viewed here:

http://jcommander.org/#Syntax
### Where does this help

This helps in
- Passing passwords without seeing them in the commandline directly
- Passing complex options that are long and/or contain special characters
