### PR TITLE
Provide enum values for argument usage help

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/EnumOptionHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/EnumOptionHandler.java
@@ -1,5 +1,7 @@
 package org.kohsuke.args4j.spi;
 
+import java.util.ResourceBundle;
+
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.OptionDef;
@@ -54,5 +56,10 @@ public class EnumOptionHandler<T extends Enum<T>> extends OptionHandler<T> {
     	rv.delete(rv.length()-3, rv.length());
     	rv.append("]");
     	return rv.toString();
+    }
+
+    @Override
+    public String getMetaVariable(ResourceBundle rb) {
+        return getDefaultMetaVariable();
     }
 }

--- a/args4j/src/org/kohsuke/args4j/spi/OptionHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/OptionHandler.java
@@ -74,7 +74,7 @@ public abstract class OptionHandler<T> {
      */
     public abstract String getDefaultMetaVariable();
 
-    public final String getMetaVariable(ResourceBundle rb) {
+    public String getMetaVariable(ResourceBundle rb) {
         String token = option.metaVar();
         if(token.length()==0)
             token = getDefaultMetaVariable();


### PR DESCRIPTION
Previously users could have a useful argument name or useful argument
values:

```
@Argument(required = true, usage = "usage")
Unable to parse command line arguments: Argument "" is required
 [PENNY | NICKEL | DIME | QUARTER] : usage

@Argument(metaVar = "coin", required = true, usage = "usage")
Unable to parse command line arguments: Argument "coin" is required
 coin : usage
```

Now arguments with metaVar yield:

```
@Argument(metaVar = "coin", required = true, usage = "usage")
Unable to parse command line arguments: Argument "coin" is required
 [PENNY | NICKEL | DIME | QUARTER] : usage
```

Which more closely matches the option behavior:

```
@Option(name = "--coin", required = true, usage = "usage")
Unable to parse command line arguments: Option "--coin" is required
 --coin [PENNY | NICKEL | DIME | QUARTER] : usage
```
