### PR TITLE
Provide subcommand names for argument usage help

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/OptionHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/OptionHandler.java
@@ -74,7 +74,7 @@ public abstract class OptionHandler<T> {
      */
     public abstract String getDefaultMetaVariable();
 
-    public final String getMetaVariable(ResourceBundle rb) {
+    public String getMetaVariable(ResourceBundle rb) {
         String token = option.metaVar();
         if(token.length()==0)
             token = getDefaultMetaVariable();

--- a/args4j/src/org/kohsuke/args4j/spi/SubCommandHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/SubCommandHandler.java
@@ -7,6 +7,7 @@ import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.OptionDef;
 
 import java.util.AbstractList;
+import java.util.ResourceBundle;
 
 /**
  * {@link OptionHandler} used with {@link Argument} for parsing typical "sub-command" pattern.
@@ -148,6 +149,18 @@ public class SubCommandHandler extends OptionHandler<Object> {
 
     @Override
     public String getDefaultMetaVariable() {
-        return Messages.DEFAULT_META_SUB_COMMAND_HANDLER.format();            
+        StringBuffer rv = new StringBuffer();
+        rv.append("[");
+        for (SubCommand sc : commands.value()) {
+            rv.append(sc.name()).append(" | ");
+        }
+        rv.delete(rv.length()-3, rv.length());
+        rv.append("]");
+        return rv.toString();
+    }
+
+    @Override
+    public String getMetaVariable(ResourceBundle rb) {
+        return getDefaultMetaVariable();
     }
 }


### PR DESCRIPTION
Before this commit args4j displayed only the metaVar and usage:

Unable to parse command line arguments: Argument "metaVar" is required
Valid options include:
 metaVar : usage

With this commit it displays all subcommand names:

Unable to parse command line arguments: Argument "metaVar" is required
Valid options include:
 [checkout | commit] : usage

This commit follows on to #76.
