### PR TITLE
Option to disable the at-syntax

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -524,7 +524,10 @@ public class CmdLineParser {
         
         checkNonNull(args, "args");
         
-        String expandedArgs[] = expandAtFiles(args);
+        String expandedArgs[] = args;
+        if (parserProperties.getAtSyntax()) {
+            expandedArgs = expandAtFiles(args);
+        }
         CmdLineImpl cmdLine = new CmdLineImpl(expandedArgs);
 
         Set<OptionHandler> present = new HashSet<OptionHandler>();

--- a/args4j/src/org/kohsuke/args4j/ParserProperties.java
+++ b/args4j/src/org/kohsuke/args4j/ParserProperties.java
@@ -16,7 +16,8 @@ public class ParserProperties {
     private int usageWidth = DEFAULT_USAGE_WIDTH;
     private Comparator<OptionHandler> optionSorter = DEFAULT_COMPARATOR;
     private String optionValueDelimiter=" ";
-
+    private boolean atSyntax = true;
+    
     private ParserProperties() {
     }
 
@@ -26,6 +27,26 @@ public class ParserProperties {
      */
     public static ParserProperties defaults() {
         return new ParserProperties();
+    }
+
+    /** Toggles the parsing of @-prefixes in values.
+     * If a command line value starts with @, it is interpreted
+     * as being a file, loaded, and interpreted as if
+     * the file content would have been passed to the command line.
+     * @param atSyntax {@code true} if at sign is being parsed, {@code false}
+     * if it is to be ignored. Defaults to {@code true}.
+     * @see #getAtSyntax() 
+     */
+    public ParserProperties withAtSyntax(boolean atSyntax) {
+        this.atSyntax = atSyntax;
+        return this;
+    }
+    
+    /** Gets whether @-prefix-parsing is enabled.
+     * @see #withAtSyntax(boolean) 
+     */
+    public boolean getAtSyntax() {
+        return atSyntax;
     }
 
     /**

--- a/args4j/test/org/kohsuke/args4j/AtOption.java
+++ b/args4j/test/org/kohsuke/args4j/AtOption.java
@@ -7,4 +7,7 @@ public class AtOption {
     
     @Option(name="-noUsage")
     public String noUsage;
+    
+    @Argument
+    public String arguments[];
 }

--- a/args4j/test/org/kohsuke/args4j/AtOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/AtOptionTest.java
@@ -3,6 +3,7 @@ package org.kohsuke.args4j;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Arrays;
 
 /**
  * Tests the AT sign that reads options from an external file.
@@ -25,7 +26,8 @@ public class AtOptionTest extends Args4JTestBase<AtOption> {
         parser.parseArgument(args);
         
         assertEquals("foo", testObject.str);
-        assertEquals(null, testObject.noUsage);
+        assertNull(testObject.noUsage);
+        assertNull(testObject.arguments);
         
         tmp.delete();
     }
@@ -42,6 +44,7 @@ public class AtOptionTest extends Args4JTestBase<AtOption> {
         
         assertEquals("foo", testObject.str);
         assertEquals("lala", testObject.noUsage);
+        assertNull(testObject.arguments);
         
         tmp.delete();
     }
@@ -58,7 +61,30 @@ public class AtOptionTest extends Args4JTestBase<AtOption> {
         
         assertEquals("foo", testObject.str);
         assertEquals("lala", testObject.noUsage);
+        assertNull(testObject.arguments);
         
         tmp.delete();
     }
+    
+    public void testAtOptsWithBeingDisabled() throws IOException, CmdLineException {
+        
+        parser.getProperties().withAtSyntax(false);
+        
+        File tmp = File.createTempFile("atoption", null);
+        PrintWriter printWriter = new PrintWriter(tmp);
+        printWriter.println("-string\nfoo");
+        printWriter.close();
+        
+        // this time the @-option gets not interpreted because
+        // it's disabled
+        args = new String[]{"-noUsage", "foo", "@"+tmp.getAbsolutePath()};
+        parser.parseArgument(args);
+        
+        assertEquals("default", testObject.str);
+        assertEquals("foo", testObject.noUsage);
+        assertEquals(Arrays.asList(new String[] {"@"+tmp.getAbsolutePath()}), 
+                Arrays.asList(testObject.arguments));
+        
+        tmp.delete();
+    }    
 }


### PR DESCRIPTION
At parsing influences command line parsing a lot. It can easily be bringing problems. I'm offering the option to disable it per configuration.
