### PR TITLE
Prevent setting value of final field

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/Setters.java
+++ b/args4j/src/org/kohsuke/args4j/spi/Setters.java
@@ -28,7 +28,7 @@ public class Setters {
     }
 
     public static Setter create(Field f, Object bean) {
-		if (Modifier.isFinal(f.getModifiers()))
+        if (Modifier.isFinal(f.getModifiers()))
             throw new IllegalStateException(String.format("Cannot set value to a final field '%s'.", f.getName()));
         if(f.getType().isArray())
             return new ArrayFieldSetter(bean,f);

--- a/args4j/src/org/kohsuke/args4j/spi/Setters.java
+++ b/args4j/src/org/kohsuke/args4j/spi/Setters.java
@@ -1,11 +1,12 @@
 package org.kohsuke.args4j.spi;
 
-import org.kohsuke.args4j.CmdLineParser;
-
-import java.lang.reflect.Field;
 import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.List;
+
+import org.kohsuke.args4j.CmdLineParser;
 
 /**
  * Factory of {@link Setter}s.
@@ -27,6 +28,8 @@ public class Setters {
     }
 
     public static Setter create(Field f, Object bean) {
+		if (Modifier.isFinal(f.getModifiers()))
+            throw new IllegalStateException(String.format("Cannot set value to a final field '%s'.", f.getName()));
         if(f.getType().isArray())
             return new ArrayFieldSetter(bean,f);
         if(List.class.isAssignableFrom(f.getType()))

--- a/args4j/test/org/kohsuke/args4j/spi/SettersTest.java
+++ b/args4j/test/org/kohsuke/args4j/spi/SettersTest.java
@@ -1,0 +1,40 @@
+package org.kohsuke.args4j.spi;
+
+import java.lang.reflect.Field;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+/**
+ * @author dantuch
+ */
+@SuppressWarnings({"static-method", "unused"})
+public class SettersTest extends TestCase {
+
+    private final String finalField = "thisValueMakesItFinal";
+    private String mutableField;
+
+    public void testSNotCreateSetterForFinalField() throws Exception {
+        // given
+        Exception illegalStateException = null;
+        Field f = SettersTest.class.getDeclaredField("finalField");
+        // when
+        try {
+            Setters.create(f, null);
+        } catch (IllegalStateException e) {
+            illegalStateException = e;
+        }
+        // then asset the exception object
+        Assert.assertNotNull("No expected exception", illegalStateException);
+    }
+
+    public void testSCreateSetterForMutableField() throws Exception {
+        // given
+        Field f = SettersTest.class.getDeclaredField("mutableField");
+        // when
+        @SuppressWarnings("rawtypes")
+        Setter created = Setters.create(f, null);
+        // then
+        Assert.assertNotNull(created);
+    }
+}


### PR DESCRIPTION
Final fields should not be set by reflection. They are final, so default value is expected to be constant. Resetting that value may occur in ignoring new value, if getter method was inlined by compiler's optimization.