### PR TITLE
Fix for MessageFormat '{0}' which will print as raw {0}, not the resolve...

### DIFF
--- a/args4j/src/org/kohsuke/args4j/Messages_de.properties
+++ b/args4j/src/org/kohsuke/args4j/Messages_de.properties
@@ -13,7 +13,7 @@ UNDEFINED_OPTION = \
     "{0}" ist keine g\u00fcltige Option
 
 NO_ARGUMENT_ALLOWED = \
-    Kein Argument erlaubt: {0}
+    Kein Argument erlaubt: "{0}"
 
 REQUIRED_OPTION_MISSING = \
     Option "{0}" wird ben\u00f6tigt
@@ -22,25 +22,25 @@ REQUIRED_ARGUMENT_MISSING = \
     Argument "{0}" wird ben\u00f6tigt
     
 TOO_MANY_ARGUMENTS = \
-    Zu viele Argumente: {0}
+    Zu viele Argumente: "{0}"
 
 METADATA_ERROR = \
     Kann die Args4J-Metadaten nicht lesen
 
 MULTIPLE_USE_OF_ARGUMENT = \
-    Das Argument mit Index {0} ist mehr als einmal verwendet
+    Das Argument mit Index "{0}" ist mehr als einmal verwendet
 
 MULTIPLE_USE_OF_OPTION = \
-    Die Option '{0}' ist mehr als einmal verwendet
+    Die Option "{0}" ist mehr als einmal verwendet
 
 UNKNOWN_HANDLER = \
-    Es ist kein OptionHandler f\u00fcr '{0}' registriert
+    Es ist kein OptionHandler f\u00fcr "{0}" registriert
 
 NO_OPTIONHANDLER = \
     Ist keine OptionHandler Klasse
 
 NO_CONSTRUCTOR_ON_HANDLER = \
-    {0} hat nicht den notwendigen Konstruktor
+    "{0}" hat nicht den notwendigen Konstruktor
 
 REQUIRES_OPTION_MISSING = \
     Option "{0}" ben\u00f6tigt die Option(en) {1}

--- a/args4j/test/org/kohsuke/args4j/CmdLineExceptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/CmdLineExceptionTest.java
@@ -52,7 +52,7 @@ public class CmdLineExceptionTest extends TestCase {
             CmdLineException e = new CmdLineException(parser, Messages.NO_ARGUMENT_ALLOWED, "foofoo");
 
             assertEquals("No argument is allowed: foofoo", e.getMessage());
-            assertEquals("Kein Argument erlaubt: foofoo", e.getLocalizedMessage());
+            assertEquals("Kein Argument erlaubt: \"foofoo\"", e.getLocalizedMessage());
             assertSame(parser, e.getParser());
         } catch (Exception e1) {
             Locale.setDefault(cur);


### PR DESCRIPTION
Fixes the bug that ...

Exception in thread "main" org.kohsuke.args4j.IllegalAnnotationError: Die Option {0} ist mehr als einmal verwendet
	at org.kohsuke.args4j.CmdLineParser.checkOptionNotInMap(CmdLineParser.java:203)
	at org.kohsuke.args4j.CmdLineParser.addOption(CmdLineParser.java:180)
	at org.kohsuke.args4j.ClassParser.parse(ClassParser.java:34)
	at org.kohsuke.args4j.CmdLineParser.<init>(CmdLineParser.java:118)
	at org.kohsuke.args4j.CmdLineParser.<init>(CmdLineParser.java:93)
	at org.oneandone.idev.johanna.JohannahServer.main(JohannahServer.java:170)
