### PR TITLE
pom: include sources in the bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
           <instructions>
             <Bundle-SymbolicName>org.kohsuke.${pom.artifactId}</Bundle-SymbolicName>
             <_includeresource>${basedir}/../LICENSE</_includeresource>
+            <_sources>true</_sources>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
So that debugging into the args4j code becomes effortless with
bndtools in Eclipse

Signed-off-by: Ferry Huberts <ferry.huberts@pelagic.nl>