### PR TITLE
Print default value in usage

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -368,9 +368,9 @@ public class CmdLineParser {
     	}
     }
 
-    private static String createDefaultValuePart(OptionHandler handler) {
+    private String createDefaultValuePart(OptionHandler handler) {
         String defaultValuePart = "";
-        if (!handler.option.required() && handler.setter instanceof Getter) {
+        if (parserProperties.getShowDefaults() && !handler.option.required() && handler.setter instanceof Getter) {
             Getter getter = (Getter)handler.setter;
             Object defObj = getter.getValue();
             if (defObj != null) {

--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -374,7 +374,8 @@ public class CmdLineParser {
             Getter getter = (Getter)handler.setter;
             Object defObj = getter.getValue();
             if (defObj != null) {
-                String defaultStr = Messages.DEFAULT_VALUE.format(defObj.toString()); // TODO arrays?
+                String defObjStr = getter.toString(defObj);
+                String defaultStr = Messages.DEFAULT_VALUE.format(defObjStr);
                 defaultValuePart = " " + defaultStr;
             }
         }

--- a/args4j/src/org/kohsuke/args4j/Messages.java
+++ b/args4j/src/org/kohsuke/args4j/Messages.java
@@ -22,7 +22,8 @@ enum Messages implements Localizable {
     NO_CONSTRUCTOR_ON_HANDLER,
     REQUIRES_OPTION_MISSING,
     FORBIDDEN_OPTION_PRESENT,
-    NO_SUCH_FILE
+    NO_SUCH_FILE,
+    DEFAULT_VALUE
     ;
 
     public String formatWithLocale( Locale locale, Object... args ) {

--- a/args4j/src/org/kohsuke/args4j/Messages.properties
+++ b/args4j/src/org/kohsuke/args4j/Messages.properties
@@ -42,3 +42,6 @@ FORBIDDEN_OPTION_PRESENT = \
 
 NO_SUCH_FILE = \
     No such file: {0}
+
+DEFAULT_VALUE = \
+    (default: {0})

--- a/args4j/src/org/kohsuke/args4j/Messages_de.properties
+++ b/args4j/src/org/kohsuke/args4j/Messages_de.properties
@@ -44,3 +44,6 @@ NO_CONSTRUCTOR_ON_HANDLER = \
 
 REQUIRES_OPTION_MISSING = \
     Option "{0}" ben\u00f6tigt die Option(en) {1}
+
+DEFAULT_VALUE = \
+    (Vorgabe: {0})

--- a/args4j/src/org/kohsuke/args4j/ParserProperties.java
+++ b/args4j/src/org/kohsuke/args4j/ParserProperties.java
@@ -17,6 +17,7 @@ public class ParserProperties {
     private Comparator<OptionHandler> optionSorter = DEFAULT_COMPARATOR;
     private String optionValueDelimiter=" ";
     private boolean atSyntax = true;
+    private boolean showDefaults = true;
     
     private ParserProperties() {
     }
@@ -44,6 +45,7 @@ public class ParserProperties {
         return this;
     }
     
+    
     /**
      * Gets whether @-prefix-parsing is enabled.
      * @see #withAtSyntax(boolean) 
@@ -52,6 +54,25 @@ public class ParserProperties {
         return atSyntax;
     }
 
+    /**
+     * Toggles the showing of default values in the command line help.
+     * @param showDefaults {@code true} if to show defaults, {@code false}
+     * otherweise. Defaults to {@code true}.
+     * @see #getShowDefaults() 
+     */
+    public ParserProperties withShowDefaults(boolean showDefaults) {
+        this.showDefaults = showDefaults;
+        return this;
+    }    
+    
+    /**
+     * Gets whether show defaults is enabled.
+     * @see #withShowDefaults(boolean) 
+     */
+    public boolean getShowDefaults() {
+        return showDefaults;
+    }
+    
     /**
      * Sets the width of a usage line.
      * If the usage message is longer than this value, the parser wraps the line.

--- a/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
@@ -101,7 +101,7 @@ final class ArrayFieldSetter implements Getter, Setter {
         f.set(bean, ary);
     }
 
-    public Object getValue() throws CmdLineException {
+    public Object getValue() {
         f.setAccessible(true);
         try {        
             return f.get(bean);

--- a/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
@@ -6,6 +6,7 @@ import org.kohsuke.args4j.IllegalAnnotationError;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 
 /**
  * {@link Setter} that allows multiple values to be stored into one array field.
@@ -108,6 +109,30 @@ final class ArrayFieldSetter implements Getter, Setter {
         catch (IllegalAccessException ex) {
             throw new IllegalAccessError(ex.getMessage());
         }
+    }
+
+    public String toString(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder();
+               
+        int len = Array.getLength(value);
+
+        sb.append("[");
+        
+        for (int i=0; i < len; i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            Object element = Array.get(value, i);
+            String elementStr = element != null ? element.toString() : "null";
+            sb.append(elementStr);
+        }
+        
+        sb.append("]");
+            
+        return sb.toString();
     }
 }
 

--- a/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
@@ -6,6 +6,7 @@ import org.kohsuke.args4j.IllegalAnnotationError;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import org.kohsuke.args4j.CmdLineException;
 
 /**
  * {@link Setter} that allows multiple values to be stored into one array field.
@@ -18,7 +19,7 @@ import java.lang.reflect.Field;
  *
  * @author Kohsuke Kawaguchi
  */
-final class ArrayFieldSetter implements Setter {
+final class ArrayFieldSetter implements Getter, Setter {
     private final Object bean;
     private final Field f;
     
@@ -98,6 +99,16 @@ final class ArrayFieldSetter implements Setter {
         }
 
         f.set(bean, ary);
+    }
+
+    public Object getValue() throws CmdLineException {
+        f.setAccessible(true);
+        try {        
+            return f.get(bean);
+        } 
+        catch (IllegalAccessException ex) {
+            throw new IllegalAccessError(ex.getMessage());
+        }
     }
 }
 

--- a/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
@@ -126,7 +126,7 @@ final class ArrayFieldSetter implements Getter, Setter {
                 sb.append(", ");
             }
             Object element = Array.get(value, i);
-            String elementStr = element != null ? element.toString() : "null";
+            String elementStr = element != null ? element.toString() : NULL;
             sb.append(elementStr);
         }
         

--- a/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ArrayFieldSetter.java
@@ -6,7 +6,6 @@ import org.kohsuke.args4j.IllegalAnnotationError;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
-import org.kohsuke.args4j.CmdLineException;
 
 /**
  * {@link Setter} that allows multiple values to be stored into one array field.

--- a/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Field;
  *
  * @author Kohsuke Kawaguchi
  */
-public final class FieldSetter implements Setter {
+public final class FieldSetter implements Getter, Setter {
     private final Field f;
     private final Object bean;
 

--- a/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
@@ -63,6 +63,6 @@ public final class FieldSetter implements Getter, Setter {
     }
 
     public String toString(Object value) {
-        return value != null ? value.toString() : "null";
+        return value != null ? value.toString() : NULL;
     }
 }

--- a/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/FieldSetter.java
@@ -61,4 +61,8 @@ public final class FieldSetter implements Getter, Setter {
             }
         }
     }
+
+    public String toString(Object value) {
+        return value != null ? value.toString() : "null";
+    }
 }

--- a/args4j/src/org/kohsuke/args4j/spi/Getter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/Getter.java
@@ -6,6 +6,9 @@ package org.kohsuke.args4j.spi;
  * @author Stephan Fuhrmann
  */
 public interface Getter<T> {
+    
+    final static String NULL = "null";
+    
     /**
      * Gets the value of the property of the option bean.
      *

--- a/args4j/src/org/kohsuke/args4j/spi/Getter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/Getter.java
@@ -1,0 +1,17 @@
+package org.kohsuke.args4j.spi;
+
+/**
+ * Interface that can be instantiated to get default values.
+ * @see Setter
+ * @author Stephan Fuhrmann
+ */
+public interface Getter<T> {
+    /**
+     * Gets the value of the property of the option bean.
+     *
+     * <p>
+     * A {@link Getter} object has an implicit knowledge about the property it's getting,
+     * and the instance of the option bean.
+     */
+    T getValue();
+}

--- a/args4j/src/org/kohsuke/args4j/spi/Getter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/Getter.java
@@ -14,4 +14,11 @@ public interface Getter<T> {
      * and the instance of the option bean.
      */
     T getValue();
+    
+    /**
+     * Formats the value for outputting it to the command line help.
+     * @param value the value as returned by {@link #getValue()}
+     * @return the human readable value representation.
+     */
+    String toString(T value);
 }

--- a/args4j/src/org/kohsuke/args4j/spi/MultiValueFieldSetter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/MultiValueFieldSetter.java
@@ -14,7 +14,7 @@ import java.util.List;
  *
  * @author Kohsuke Kawaguchi
  */
-final class MultiValueFieldSetter implements Setter {
+final class MultiValueFieldSetter implements Getter, Setter {
     private final Object bean;
     private final Field f;
 
@@ -74,5 +74,19 @@ final class MultiValueFieldSetter implements Setter {
             throw new IllegalAnnotationError(Messages.ILLEGAL_LIST.format(f));
 
         ((List)o).add(value);
+    }
+
+    public Object getValue() {
+        try {
+            f.setAccessible(true);
+            return f.get(bean);
+        }
+        catch (IllegalAccessException ex) {
+            throw new IllegalAccessError(ex.getMessage());
+        }
+    }
+
+    public String toString(Object value) {
+        return value != null ? value.toString() : NULL;
     }
 }

--- a/args4j/src/org/kohsuke/args4j/spi/Setter.java
+++ b/args4j/src/org/kohsuke/args4j/spi/Setter.java
@@ -13,7 +13,7 @@ import java.lang.reflect.AnnotatedElement;
  * This abstracts away the difference between a field and a setter method, 
  * which object we are setting the value to,
  * and/or how we handle collection fields differently.
- *
+ * @see Getter
  * @author Kohsuke Kawaguchi
  */
 public interface Setter<T> {

--- a/args4j/test/org/kohsuke/args4j/DefaultOption.java
+++ b/args4j/test/org/kohsuke/args4j/DefaultOption.java
@@ -1,5 +1,8 @@
 package org.kohsuke.args4j;
 
+import java.util.Arrays;
+import java.util.List;
+
 @SuppressWarnings("unused")
 public class DefaultOption {
     @Option(name="-str",usage="set a string")
@@ -33,6 +36,9 @@ public class DefaultOption {
     
     @Option(name="-drink", usage="my favorite drink")
     public DrinkName drink = DrinkName.BEER;
+    
+    @Option(name="-drinkList", usage="my favorite drinks")
+    public List<DrinkName> drinkList = Arrays.asList(DrinkName.BEER, DrinkName.BRANDY);
     
     @Argument
     public String arguments[] = new String[] { "foo", "bar" };

--- a/args4j/test/org/kohsuke/args4j/DefaultOption.java
+++ b/args4j/test/org/kohsuke/args4j/DefaultOption.java
@@ -17,7 +17,7 @@ public class DefaultOption {
     @Option(name="-byteVal", usage = "my favorite byte")
     public byte byteVal;
     
-    @Option(name="-strArray")
+    @Option(name="-strArray", usage="my favorite strarr")
     public String strArray[] = new String[] { "san", "dra", "chen"};
     
     public enum DrinkName {
@@ -28,10 +28,10 @@ public class DefaultOption {
         BRANDY
     };
     
-    @Option(name="-drinkArray")
+    @Option(name="-drinkArray", usage="my favorite drinks")
     public DrinkName drinkArray[] = new DrinkName[] { DrinkName.BEER, DrinkName.BOURBON };
     
-    @Option(name="-drink")
+    @Option(name="-drink", usage="my favorite drink")
     public DrinkName drink = DrinkName.BEER;
     
     @Argument

--- a/args4j/test/org/kohsuke/args4j/DefaultOption.java
+++ b/args4j/test/org/kohsuke/args4j/DefaultOption.java
@@ -1,0 +1,39 @@
+package org.kohsuke.args4j;
+
+@SuppressWarnings("unused")
+public class DefaultOption {
+    @Option(name="-str",usage="set a string")
+    public String str = "pretty string";
+    
+    @Option(name="-req",usage="set a string", required = true)
+    public String req = "required";
+    
+    @Option(name="-noDefault")
+    public String noDefault;
+    
+    @Option(name="-noDefaultReq", required = true)
+    public String noDefaultReq;
+    
+    @Option(name="-byteVal", usage = "my favorite byte")
+    public byte byteVal;
+    
+    @Option(name="-strArray")
+    public String strArray[] = new String[] { "san", "dra", "chen"};
+    
+    public enum DrinkName {
+        BEER,
+        WHISKEY,
+        SCOTCH,
+        BOURBON,
+        BRANDY
+    };
+    
+    @Option(name="-drinkArray")
+    public DrinkName drinkArray[] = new DrinkName[] { DrinkName.BEER, DrinkName.BOURBON };
+    
+    @Option(name="-drink")
+    public DrinkName drink = DrinkName.BEER;
+    
+    @Argument
+    public String arguments[] = new String[] { "foo", "bar" };
+}

--- a/args4j/test/org/kohsuke/args4j/DefaultOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/DefaultOptionTest.java
@@ -1,0 +1,30 @@
+package org.kohsuke.args4j;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+/**
+ * Tests the default option value outputs in many ways.
+ * @author Stephan Fuhrmann
+ */
+public class DefaultOptionTest extends Args4JTestBase<DefaultOption> {
+    @Override
+    public DefaultOption getTestObject() {
+        return new DefaultOption();
+    }
+    
+    private String findContaining(String searchString, String lines[]) {
+        for (String line : lines) {
+            if (line.contains(searchString))
+                return line;
+        }
+        throw new NoSuchElementException("Could not find "+searchString);
+    }
+
+    public void testParseArgumentWithEmptyArgs() throws IOException, CmdLineException {
+        
+        String usageMessage[] = getUsageMessage();
+        int a = 1;
+    }
+    
+}

--- a/args4j/test/org/kohsuke/args4j/DefaultOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/DefaultOptionTest.java
@@ -23,6 +23,8 @@ public class DefaultOptionTest extends Args4JTestBase<DefaultOption> {
         " BOURBON | BRANDY]                         ",
         " -drinkArray [BEER | WHISKEY | SCOTCH   : my favorite drinks (default: [BEER,",
         " | BOURBON | BRANDY]                      BOURBON])",
+        " -drinkList [BEER | WHISKEY | SCOTCH |  : my favorite drinks (default: [BEER,",
+        " BOURBON | BRANDY]                        BRANDY])",
         " -req VAL                               : set a string",
         " -str VAL                               : set a string (default: pretty string)",
         " -strArray VAL                          : my favorite strarr (default: [san,",

--- a/args4j/test/org/kohsuke/args4j/DefaultOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/DefaultOptionTest.java
@@ -1,30 +1,37 @@
 package org.kohsuke.args4j;
 
 import java.io.IOException;
-import java.util.NoSuchElementException;
 
 /**
  * Tests the default option value outputs in many ways.
  * @author Stephan Fuhrmann
  */
 public class DefaultOptionTest extends Args4JTestBase<DefaultOption> {
+    
     @Override
     public DefaultOption getTestObject() {
         return new DefaultOption();
     }
     
-    private String findContaining(String searchString, String lines[]) {
-        for (String line : lines) {
-            if (line.contains(searchString))
-                return line;
-        }
-        throw new NoSuchElementException("Could not find "+searchString);
-    }
-
     public void testParseArgumentWithEmptyArgs() throws IOException, CmdLineException {
         
         String usageMessage[] = getUsageMessage();
-        int a = 1;
+        
+        String testMessageExpected[] = new String[] {
+        " -byteVal N                             : my favorite byte (default: 0)",
+        " -drink [BEER | WHISKEY | SCOTCH |      : my favorite drink (default: BEER)",
+        " BOURBON | BRANDY]                         ",
+        " -drinkArray [BEER | WHISKEY | SCOTCH   : my favorite drinks (default: [BEER,",
+        " | BOURBON | BRANDY]                      BOURBON])",
+        " -req VAL                               : set a string",
+        " -str VAL                               : set a string (default: pretty string)",
+        " -strArray VAL                          : my favorite strarr (default: [san,",
+        "                                          dra, chen])"
+        };
+
+        for (int i=0; i < usageMessage.length; i++) {
+            assertEquals("Line "+(i+1)+" wrong", testMessageExpected[i], usageMessage[i]);
+        }
     }
     
 }

--- a/args4j/test/org/kohsuke/args4j/LongUsageTest.java
+++ b/args4j/test/org/kohsuke/args4j/LongUsageTest.java
@@ -15,7 +15,7 @@ public class LongUsageTest extends Args4JTestBase<LongUsage> {
             parser.parseArgument(args);
         } catch (CmdLineException e) {
             String expectedLine1 = " -LongNamedStringOption USE_A_NICE_STRING : set a string";
-            String expectedLine2 = " -i N                                     : set an int";
+            String expectedLine2 = " -i N                                     : set an int (default: 0)";
             String[] usageLines = getUsageMessage();
             assertUsageLength(2);
             assertEquals("First line wrong", expectedLine1, usageLines[0]);
@@ -33,7 +33,7 @@ public class LongUsageTest extends Args4JTestBase<LongUsage> {
             parser.parseArgument(args);
         } catch (CmdLineException e) {
             String expectedLine1 = " -LongNamedStringOption USE_A_NICE_STRING : set a string";
-            String expectedLine2 = " -i N                                     : set an int";
+            String expectedLine2 = " -i N                                     : set an int (default: 0)";
             String[] usageLines = getUsageMessage();
             assertUsageLength(2);
             assertEquals("First line wrong", expectedLine1, usageLines[0]);

--- a/args4j/test/org/kohsuke/args4j/SimpleStringTest.java
+++ b/args4j/test/org/kohsuke/args4j/SimpleStringTest.java
@@ -37,7 +37,7 @@ public class SimpleStringTest extends Args4JTestBase<SimpleString> {
             fail("Doesnt detect wrong parameters.");
         } catch (CmdLineException e) {
             String expectedError = "\"-wrong-usage\" is not a valid option";
-            String expectedUsage   = " -str VAL : set a string";
+            String expectedUsage   = " -str VAL : set a string (default: default)";
             String[] usageLines = getUsageMessage();
             assertErrorMessagePrefix(expectedError, e);
             assertUsageLength(1);
@@ -52,7 +52,7 @@ public class SimpleStringTest extends Args4JTestBase<SimpleString> {
             fail("Should miss one parameter.");
         } catch (CmdLineException e) {
             String expectedError = "Option \"-str\" takes an operand";
-            String expectedUsage   = " -str VAL : set a string";
+            String expectedUsage   = " -str VAL : set a string (default: default)";
             String[] usageLines = getUsageMessage();
             String errorMessage = e.getMessage();
             assertUsageLength(1);


### PR DESCRIPTION
This adds support for outputting the preset default values to the usage output!

An example usage with defaults looks like this:

     -drink [BEER | WHISKEY | SCOTCH |      : my favorite drink (default: BEER)
     BOURBON | BRANDY]                         
     -drinkArray [BEER | WHISKEY | SCOTCH   : my favorite drinks (default: [BEER,
     | BOURBON | BRANDY]                      BOURBON])

This solves issue #7 

The only thing missing is getting defaults from field setters because there's no real standard here. The annotated field could be a JavaBeans setXXX(...) method, but also a foo(...) method. Calculating the getter from this would be close to magic.
