### PR TITLE
Bumped version of junit framework

### DIFF
--- a/args4j-tools/pom.xml
+++ b/args4j-tools/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/args4j/pom.xml
+++ b/args4j/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Moved junit version to 4.11. Benefits:
* Full Compatible with current tests
* IDEs have the new possibility to do per-method-tests
