### PR TITLE
Show options without usage attribute

### DIFF
--- a/args4j-tools/src/org/kohsuke/args4j/apt/AnnotationProcessorImpl.java
+++ b/args4j-tools/src/org/kohsuke/args4j/apt/AnnotationProcessorImpl.java
@@ -109,13 +109,9 @@ public class AnnotationProcessorImpl extends AbstractProcessor {
         if(o==null) return;
 
         String usage = getUsage(o);
-        if(isOptionHidden(usage))    return;
+        if(o.hidden())    return;
 
         visitor.onOption(new OptionWithUsage(o, usage));
-    }
-
-    private boolean isOptionHidden(String usage) {
-        return usage==null || usage.length()==0;
     }
 
     private String getUsage(Option o) {
@@ -124,7 +120,7 @@ public class AnnotationProcessorImpl extends AbstractProcessor {
         else
             return resource.getProperty(o.usage());
     }
-
+    
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
 

--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -334,10 +334,8 @@ public class CmdLineParser {
      * @see Setter#asAnnotatedElement()
      */
     protected void printOption(PrintWriter out, OptionHandler handler, int len, ResourceBundle rb, OptionHandlerFilter filter) {
-    	// Hiding options without usage information
-    	if (handler.option.usage() == null ||
-            handler.option.usage().length() == 0 ||
-            !filter.select(handler)) {
+    	// Hiding options filtered
+    	if (!filter.select(handler)) {
     		return;
     	}
 
@@ -348,13 +346,14 @@ public class CmdLineParser {
 
     	// Line wrapping
     	List<String> namesAndMetas = wrapLines(handler.getNameAndMeta(rb, parserProperties), widthMetadata);
-    	List<String> usages        = wrapLines(localize(handler.option.usage(),rb), widthUsage);
+        String usageString = handler.option.usage() != null ? handler.option.usage() : "";
+    	List<String> usages        = wrapLines(localize(usageString,rb), widthUsage);
 
     	// Output
     	for(int i=0; i<Math.max(namesAndMetas.size(), usages.size()); i++) {
     		String nameAndMeta = (i >= namesAndMetas.size()) ? "" : namesAndMetas.get(i);
 			String usage       = (i >= usages.size())        ? "" : usages.get(i);
-			String format      = ((nameAndMeta.length() > 0) && (i == 0))
+			String format      = ((nameAndMeta.length() > 0) && (i == 0) && usage.length() > 0)
 			                   ? " %1$-" + widthMetadata + "s : %2$-1s"
 			                   : " %1$-" + widthMetadata + "s   %2$-1s";
 			String output = String.format(format, nameAndMeta, usage);

--- a/args4j/src/org/kohsuke/args4j/Option.java
+++ b/args4j/src/org/kohsuke/args4j/Option.java
@@ -94,10 +94,7 @@ public @interface Option {
      * by querying a {@link ResourceBundle} instance supplied to
      * {@link CmdLineParser} by this key. This allows the usage
      * screen to be properly localized.
-     *
-     * <p>
-     * If this value is empty, the option will not be displayed
-     * in the usage screen.
+     * @see #hidden() 
      */
     String usage() default "";
 

--- a/args4j/test/org/kohsuke/args4j/HelpOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/HelpOptionTest.java
@@ -19,7 +19,7 @@ public class HelpOptionTest extends Args4JTestBase<HelpOption> {
             String expectedError = "Option \"-req\" is required";
             String[] usageLines = getUsageMessage();
             String errorMessage = e.getMessage();
-            assertUsageLength(2);
+            assertUsageLength(3);
             assertTrue("Got wrong error message", errorMessage.startsWith(expectedError));
         }
     }

--- a/args4j/test/org/kohsuke/args4j/SimpleStringTest.java
+++ b/args4j/test/org/kohsuke/args4j/SimpleStringTest.java
@@ -37,11 +37,11 @@ public class SimpleStringTest extends Args4JTestBase<SimpleString> {
             fail("Doesnt detect wrong parameters.");
         } catch (CmdLineException e) {
             String expectedError = "\"-wrong-usage\" is not a valid option";
-            String expectedUsage   = " -str VAL : set a string";
             String[] usageLines = getUsageMessage();
             assertErrorMessagePrefix(expectedError, e);
-            assertUsageLength(1);
-            assertEquals("Got wrong usage message", expectedUsage, usageLines[0]);
+            assertUsageLength(2);
+            assertEquals("Got wrong usage message", " -nu VAL     ", usageLines[0]);
+            assertEquals("Got wrong usage message", " -str VAL : set a string", usageLines[1]);
         }
     }
 
@@ -52,12 +52,12 @@ public class SimpleStringTest extends Args4JTestBase<SimpleString> {
             fail("Should miss one parameter.");
         } catch (CmdLineException e) {
             String expectedError = "Option \"-str\" takes an operand";
-            String expectedUsage   = " -str VAL : set a string";
             String[] usageLines = getUsageMessage();
             String errorMessage = e.getMessage();
-            assertUsageLength(1);
+            assertUsageLength(2);
             assertTrue("Got wrong error message: " + errorMessage, errorMessage.startsWith(expectedError));
-            assertEquals("Got wrong usage message", expectedUsage, usageLines[0]);
+            assertEquals("Got wrong usage message", " -nu VAL     ", usageLines[0]);
+            assertEquals("Got wrong usage message", " -str VAL : set a string", usageLines[1]);
         }
     }
     


### PR DESCRIPTION
The old behaviour was NOT showing options that have no usage. 
This was documented behaviour, but it was quite confusing because of the existance of the "hidden" flag in the Options annotation. 

One of the most important parts of args4j is showing the command line help. The expected behaviour is seeing everything. Hidden options are a special case, for them there's the "hidden" flag.

This pull req is the proposal of a new behaviour showing all options. The responsibility of showing or hiding is delegated to the filter which in my opinion is a straightforward and logic behaviour.

I hope someone will find this useful.
