### PR TITLE
remove Singleton (anti)pattern for OptionHandlerRegistry usage

### DIFF
--- a/args4j/src/org/kohsuke/args4j/OptionHandlerRegistry.java
+++ b/args4j/src/org/kohsuke/args4j/OptionHandlerRegistry.java
@@ -34,34 +34,16 @@ import org.kohsuke.args4j.spi.URLOptionHandler;
  * Manages the registration of option handlers.
  * This is good for registering custom handlers
  * for specific parameter classes not yet implemented.
- * The registry is a singleton that can be
- * retrieved with the {@link #getRegistry()} call.
+ *
  * @author Stephan Fuhrmann
  */
 public class OptionHandlerRegistry {
 
     /**
-     * The shared reference.
-     * @see #getRegistry() 
-     */
-    private static OptionHandlerRegistry instance;
-    
-    /**
-     * Gets the option handler registry singleton instance.
-     * @return a shared instance of the registry.
-     */
-    public synchronized static OptionHandlerRegistry getRegistry() {
-        if (instance == null) {
-            instance = new OptionHandlerRegistry();
-        }
-        return instance;
-    }
-    
-    /**
      * Constructs an option handler manager with the
      * default handlers initialized.
      */
-    private OptionHandlerRegistry() {
+    public OptionHandlerRegistry() {
         initHandlers();
     }
 
@@ -145,7 +127,7 @@ public class OptionHandlerRegistry {
     protected OptionHandler createOptionHandler(CmdLineParser parser, OptionDef o, Setter setter) {
         Utilities.checkNonNull(o, "CmdLineParser");
         Utilities.checkNonNull(o, "OptionDef");
-        Utilities.checkNonNull(setter, "Sette");
+        Utilities.checkNonNull(setter, "Setter");
 
         Constructor<? extends OptionHandler> handlerType;
         Class<? extends OptionHandler> h = o.handler();

--- a/args4j/test/org/kohsuke/args4j/OptionHandlerRegistryTest.java
+++ b/args4j/test/org/kohsuke/args4j/OptionHandlerRegistryTest.java
@@ -27,22 +27,6 @@ public class OptionHandlerRegistryTest extends TestCase {
         private CustomType foo;
     }
     
-    /** Tests whether OptionHandlerRegistry.getRegistry() returns an instance. */
-    public void testGetRegistry() {
-        OptionHandlerRegistry instance = OptionHandlerRegistry.getRegistry();
-        assertNotNull(instance);
-    }
-    
-    /** Tests whether OptionHandlerRegistry.getRegistry() is a real singleton. */
-    public void testGetRegistryWithSingleton() {
-        OptionHandlerRegistry instance1 = OptionHandlerRegistry.getRegistry();
-        OptionHandlerRegistry instance2 = OptionHandlerRegistry.getRegistry();
-        OptionHandlerRegistry instance3 = OptionHandlerRegistry.getRegistry();
-        
-        assertSame(instance1, instance2);
-        assertSame(instance1, instance3);
-    }
-    
     /** Tests whether unknown types raise an exception. */
     public void testCmdLineParserWithUnregistered() {
         try {        
@@ -58,9 +42,11 @@ public class OptionHandlerRegistryTest extends TestCase {
     /** Tests whether registering a handler works. */
     public void testCmdLineParserWithCustomRegistered() throws CmdLineException {
         TestBean bean = new TestBean();
-        OptionHandlerRegistry.getRegistry().registerHandler(CustomType.class,
-                CustomTypeOptionHandler.class);
-        CmdLineParser parser = new CmdLineParser(bean);
+
+        OptionHandlerRegistry registry = new OptionHandlerRegistry();
+        registry.registerHandler(CustomType.class, CustomTypeOptionHandler.class);
+
+        CmdLineParser parser = new CmdLineParser(bean, ParserProperties.defaults(), registry);
         parser.parseArgument("-foo", "5");
         
         assertEquals(5, bean.foo.value);


### PR DESCRIPTION
I've changed OptionHandlerRegistry implementation and usage to make it more testable and less coupled with CmdLineParser