### PR TITLE
CmdLineParser: mark createOptionHandler() as non-deprecated

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -127,8 +127,7 @@ public class CmdLineParser {
         Utilities.checkNonNull(setter, "Setter");
         Utilities.checkNonNull(a, "Argument");
         
-        OptionHandler h = OptionHandlerRegistry.getRegistry().createOptionHandler(this,
-                new OptionDef(a,setter.isMultiValued()),setter);
+        OptionHandler h = createOptionHandler(new OptionDef(a,setter.isMultiValued()),setter);
     	int index = a.index();
     	// make sure the argument will fit in the list
     	while (index >= arguments.size()) {
@@ -156,8 +155,7 @@ public class CmdLineParser {
         for (String alias : o.aliases()) {
         	checkOptionNotInMap(alias);
         }
-        options.add(OptionHandlerRegistry.getRegistry().createOptionHandler(
-                this, new NamedOptionDef(o), setter));
+        options.add(createOptionHandler(new NamedOptionDef(o), setter));
     }
 
     /**
@@ -185,7 +183,6 @@ public class CmdLineParser {
     /**
      * Creates an {@link OptionHandler} that handles the given {@link Option} annotation
      * and the {@link Setter} instance.
-     * @deprecated You should use {@link OptionHandlerRegistry#createOptionHandler(org.kohsuke.args4j.CmdLineParser, org.kohsuke.args4j.OptionDef, org.kohsuke.args4j.spi.Setter) } instead.
      */
     protected OptionHandler createOptionHandler(OptionDef o, Setter setter) {
         checkNonNull(o, "OptionDef");


### PR DESCRIPTION
Since b1aa90f37eaf2c7997b899e6a65cd27b451c2210 the createOptionHandler() was
deprecated and the user was routed to OptionHandlerRegistry method
instead. As a side effect the overridding of the now deprecated method
createOptionHandler() doesn't have any effect, because this method is
not get called any more from the addOption() and addArgument() methods.

The documented OptionHandlerRegistry.registerHandler() machinery cannot
be used, when a DI framework is used and the instances must be created by
the injector.

Mark createOptionHandler as non deprecated again and use it from addOption()
and addArgument() methods.

This commit partial reverts b1aa90f37eaf2c7997b899e6a65cd27b451c2210