### PR TITLE
Allow filtering options for prefix length

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -291,8 +291,10 @@ public class CmdLineParser {
             len = Math.max(len,curLen);
         }
         for (OptionHandler h: options) {
-            int curLen = getPrefixLen(h, rb);
-            len = Math.max(len,curLen);
+            if (filter.select(h)) {
+	        int curLen = getPrefixLen(h, rb);
+                len = Math.max(len,curLen);
+	    }
         }
 
         // then print


### PR DESCRIPTION
`printUsage()` filter hidden options to compute prefix length.
SampleMain could illustrate the issue: prefix length is compute using *-hidden-str2 VAL* option, but this option is not printed.
Now if an option is filtered then prefix length does not take into account this option.