### PR TITLE
Maven central batch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-args4j
+args4j [![Maven Central](https://maven-badges.herokuapp.com/maven-central/args4j/args4j/badge.svg)](https://maven-badges.herokuapp.com/maven-central/args4j/args4j)
 ======
 args4j is a small Java class library that makes it easy to parse command line options/arguments in your CUI
 application. See more info at [http://args4j.kohsuke.org/]


### PR DESCRIPTION
This PR shows the last MVN Central repository version in the readme and adds a link to the MVN repository. 
It makes it easier to find the MVN dependencies for the pom.xml.

See [here](https://github.com/sfuhrm/html2sax/blob/master/README.md) for an example (maybe the Travis CI badge is also interesting?).

Greetings,
Stephan