### PR TITLE
Modified splitToken to split on the configured option value delimiter

### DIFF
--- a/args4j/src/org/kohsuke/args4j/CmdLineParser.java
+++ b/args4j/src/org/kohsuke/args4j/CmdLineParser.java
@@ -1,5 +1,10 @@
 package org.kohsuke.args4j;
 
+import org.kohsuke.args4j.spi.Getter;
+import org.kohsuke.args4j.spi.OptionHandler;
+import org.kohsuke.args4j.spi.Parameters;
+import org.kohsuke.args4j.spi.Setter;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -16,11 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
-import org.kohsuke.args4j.spi.Getter;
-
-import org.kohsuke.args4j.spi.OptionHandler;
-import org.kohsuke.args4j.spi.Parameters;
-import org.kohsuke.args4j.spi.Setter;
 
 import static org.kohsuke.args4j.Utilities.checkNonNull;
 
@@ -440,7 +440,10 @@ public class CmdLineParser {
          */
         void splitToken() {
             if (pos < args.length && pos >= 0) {
-                int idx = args[pos].indexOf("=");
+                int idx = args[pos].indexOf(parserProperties.getOptionValueDelimiter());
+                if (idx < 0) {
+                    idx = args[pos].indexOf("="); // historical compatibility fallback
+                }
                 if (idx > 0) {
                     args[pos] = args[pos].substring(idx + 1);
                 }

--- a/args4j/test/org/kohsuke/args4j/KeyValueCustomDelimiterTest.java
+++ b/args4j/test/org/kohsuke/args4j/KeyValueCustomDelimiterTest.java
@@ -1,0 +1,46 @@
+package org.kohsuke.args4j;
+
+public class KeyValueCustomDelimiterTest extends Args4JTestBase<KeyValue> {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    testObject = getTestObject();
+
+    ParserProperties properties = ParserProperties.defaults();
+    properties.withOptionValueDelimiter(":");
+
+    parser = new CmdLineParser(testObject, properties);
+  }
+
+  @Override
+  public KeyValue getTestObject() {
+    return new KeyValue();
+  }
+
+  public void testDouble() throws CmdLineException {
+    args = new String[]{"--double:42.54"};
+    parser.parseArgument(args);
+    assertEquals(42.54, testObject._double, 0);
+  }
+
+  public void testDoubleShort() throws CmdLineException {
+    args = new String[]{"-d:42.54"};
+    parser.parseArgument(args);
+    assertEquals(42.54, testObject._double, 0);
+  }
+
+
+  public void testChar() throws CmdLineException {
+    args = new String[]{"--string:stringValue"};
+    parser.parseArgument(args);
+    assertEquals("stringValue", testObject._string);
+  }
+
+  public void testCharShort() throws CmdLineException {
+    args = new String[]{"-s:stringValue"};
+    parser.parseArgument(args);
+    assertEquals("stringValue", testObject._string);
+  }
+
+}


### PR DESCRIPTION
Uses "=" as a fallback.

Fixes issue #151