### PR TITLE
Disable @-syntax by default

### DIFF
--- a/args4j/src/org/kohsuke/args4j/ParserProperties.java
+++ b/args4j/src/org/kohsuke/args4j/ParserProperties.java
@@ -16,7 +16,7 @@ public class ParserProperties {
     private int usageWidth = DEFAULT_USAGE_WIDTH;
     private Comparator<OptionHandler> optionSorter = DEFAULT_COMPARATOR;
     private String optionValueDelimiter=" ";
-    private boolean atSyntax = true;
+    private boolean atSyntax = false;
     private boolean showDefaults = true;
     
     private ParserProperties() {
@@ -33,11 +33,16 @@ public class ParserProperties {
 
     /**
      * Toggles the parsing of @-prefixes in values.
-     * If a command line value starts with @, it is interpreted
-     * as being a file, loaded, and interpreted as if
-     * the file content would have been passed to the command line.
+     *
+     * If a command line value starts with @, it is interpreted as being a file,
+     * loaded, and interpreted as if the file content would have been passed to
+     * the command line. This behavior is potentially insecure if args4j is
+     * being accessed over a network to parse user-provided options, since it
+     * may allow users on the network to read arbitrary files on the server's
+     * filesystem.
+     *
      * @param atSyntax {@code true} if at sign is being parsed, {@code false}
-     * if it is to be ignored. Defaults to {@code true}.
+     * if it is to be ignored. Defaults to {@code false}.
      * @see #getAtSyntax() 
      */
     public ParserProperties withAtSyntax(boolean atSyntax) {

--- a/args4j/test/org/kohsuke/args4j/AtOptionTest.java
+++ b/args4j/test/org/kohsuke/args4j/AtOptionTest.java
@@ -17,6 +17,8 @@ public class AtOptionTest extends Args4JTestBase<AtOption> {
 
     public void testSimpleAt() throws IOException, CmdLineException {
         
+        parser.getProperties().withAtSyntax(true);
+        
         File tmp = File.createTempFile("atoption", null);
         PrintWriter printWriter = new PrintWriter(tmp);
         printWriter.println("-string\nfoo");
@@ -33,6 +35,8 @@ public class AtOptionTest extends Args4JTestBase<AtOption> {
     }
     
     public void testAtAfterOpts() throws IOException, CmdLineException {
+        
+        parser.getProperties().withAtSyntax(true);
         
         File tmp = File.createTempFile("atoption", null);
         PrintWriter printWriter = new PrintWriter(tmp);
@@ -51,6 +55,8 @@ public class AtOptionTest extends Args4JTestBase<AtOption> {
     
     public void testAtBeforeOpts() throws IOException, CmdLineException {
         
+        parser.getProperties().withAtSyntax(true);
+        
         File tmp = File.createTempFile("atoption", null);
         PrintWriter printWriter = new PrintWriter(tmp);
         printWriter.println("-string\nfoo");
@@ -67,8 +73,6 @@ public class AtOptionTest extends Args4JTestBase<AtOption> {
     }
     
     public void testAtOptsWithBeingDisabled() throws IOException, CmdLineException {
-        
-        parser.getProperties().withAtSyntax(false);
         
         File tmp = File.createTempFile("atoption", null);
         PrintWriter printWriter = new PrintWriter(tmp);


### PR DESCRIPTION
The @-syntax allows any user passing options parsed by args4j to
effectively read any file on the machine running the args4j application.
For the common use case of building a command-line application that can
be run by a user with shell access to a machine, this is a useful
shortcut. It doesn't increase the surface of files that the user has
access to; if they already have shell access to a machine, they can read
any files they want with `cat`.

However, args4j may also be used in environments where command-line
parsing is accessible to arbitrary users over a network. For example,
args4j can be used in conjunction with an SSH server library such as
Apache MINA to expose a limited set of SSH commands without granting
shell access to the user. In this context, users should definitely not
be allowed to read arbitrary files from the server using @-syntax.

Because the behavior is non-obvious to an implementer who doesn't
closely read the ParserProperties documentation, and because the impact
of exposing arbitrary files on a remote server is potentially so severe,
change the default for @-syntax to off.