### PR TITLE
Catch NumberFormatException thrown by OneArgumentOptionHandler parse …

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/DelimitedOptionHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/DelimitedOptionHandler.java
@@ -34,7 +34,12 @@ public abstract class DelimitedOptionHandler<T> extends OptionHandler<T> {
         String full = params.getParameter(0);
         String[] delimitedStrs = full.split(delimiter);
         for (String delimitedStr : delimitedStrs) {
-            setter.addValue(individualOptionHandler.parse(delimitedStr));
+            try {
+                setter.addValue(individualOptionHandler.parse(delimitedStr));
+            }
+            catch (NumberFormatException ex) {
+                 throw new CmdLineException(owner, Messages.ILLEGAL_OPERAND, params.getParameter(-1), delimitedStr);
+            }
         }
 
         // The number of Parameters consumed (not the number set)


### PR DESCRIPTION
Since several built-in classes extending OneArgumentOptionHandler throw NumberFormatException with parse method, it would be nice if this exception is managed directly by DelimitedOptionHandler to write an useful message.
