### PR TITLE
Removed no-op test method

### DIFF
--- a/args4j/test/org/kohsuke/args4j/PropsTest.java
+++ b/args4j/test/org/kohsuke/args4j/PropsTest.java
@@ -9,11 +9,6 @@ public class PropsTest extends Args4JTestBase<Props> {
         return new Props();
     }
 
-    public void testDoNothing() {
-        // ignore, that the other test cases are commented out
-        // JUnit doesnt like TestCases without a test-method.
-    }
-
     public void testNoValues() {
         args = new String[]{};
         try {


### PR DESCRIPTION
The comment was relevant when all other tests were commented out;
now that there are other valid tests in this file, this can be removed.