### PR TITLE
Use properties from owner parser in SubCommandHandler

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/SubCommandHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/SubCommandHandler.java
@@ -134,7 +134,7 @@ public class SubCommandHandler extends OptionHandler<Object> {
     }
 
     protected CmdLineParser configureParser(Object subCmd, SubCommand c) {
-        return new CmdLineParser(subCmd);
+        return new CmdLineParser(subCmd, owner.getProperties());
     }
 
     protected Object instantiate(SubCommand c) {


### PR DESCRIPTION
I found it surprising that setting properties on `CmdLineParser` does not affect `SubCommandhandler`s and I found it non-trivial to override this behavior: basically you need to subclass `SubCommandHandler` and do the patch proposed in this PR. 

This behavior kinda makes sense and I wonder why is it not default