### PR TITLE
Allow Enum:toString to match because toString method might be override

### DIFF
--- a/args4j/src/org/kohsuke/args4j/spi/EnumOptionHandler.java
+++ b/args4j/src/org/kohsuke/args4j/spi/EnumOptionHandler.java
@@ -25,7 +25,7 @@ public class EnumOptionHandler<T extends Enum<T>> extends OptionHandler<T> {
         String s = params.getParameter(0).replaceAll("-", "_");
         T value = null;
         for( T o : enumType.getEnumConstants() )
-            if(o.name().equalsIgnoreCase(s)) {
+            if(o.name().equalsIgnoreCase(s) || o.toString().equalsIgnoreCase(s)) {
                 value = o;
                 break;
             }


### PR DESCRIPTION
Example: AEnum.E_1X
Its toString() returns "X"
So it will be printed as "X"
But its name is "E_1X"
So "X" doesn't match, "E_1X" does