### PR TITLE
Add an automatic module name header to the JAR.

### DIFF
--- a/args4j/pom.xml
+++ b/args4j/pom.xml
@@ -31,6 +31,19 @@
         </includes>
       </testResource>
     </testResources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>args4j</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Without a module name, the library is not really usable from a modular Java 9+ project.

This would fix  #187.