### PR TITLE
Cleanup buildprocess for Maven-Central deployment

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,9 +4,7 @@
 	<classpathentry kind="src" output="args4j/target/examples" path="args4j/examples"/>
 	<classpathentry kind="src" output="args4j/target/classes" path="args4j/src"/>
 	<classpathentry kind="src" output="args4j/target/test-classes" path="args4j/test"/>
-	<classpathentry kind="lib" path="args4j/lib/ant.jar"/>
-	<classpathentry kind="lib" path="C:/jdk/150_14/lib/tools.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/150_14"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,15 @@
-#Wed Jun 18 20:01:43 CEST 2008
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/args4j-maven-plugin-example/pom.xml
+++ b/args4j-maven-plugin-example/pom.xml
@@ -13,9 +13,6 @@
 
   <description>Example of running the maven plugin</description>
 
-  <prerequisites>
-    <maven>2.0</maven>
-  </prerequisites>
   <inceptionYear>2011</inceptionYear>
 
   <build>

--- a/args4j-maven-plugin/pom.xml
+++ b/args4j-maven-plugin/pom.xml
@@ -29,6 +29,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.1</version>
     </dependency>
+	<dependency>
+		<groupId>org.apache.maven.plugin-tools</groupId>
+		<artifactId>maven-plugin-annotations</artifactId>
+		<version>3.8.1</version>
+		<scope>provided</scope>
+	</dependency>
   </dependencies>
   <build>
     <plugins>

--- a/args4j-maven-plugin/src/main/java/org/kohsuke/args4j/maven/Args4jUsageMojo.java
+++ b/args4j-maven-plugin/src/main/java/org/kohsuke/args4j/maven/Args4jUsageMojo.java
@@ -3,6 +3,8 @@ package org.kohsuke.args4j.maven;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.kohsuke.args4j.apt.Main;
 
 import java.io.*;
@@ -10,34 +12,33 @@ import java.net.URLDecoder;
 import java.util.List;
 
 /**
- * @goal usage
+ * Maven goal to create a usage description file.
  */
+@Mojo(name = "usage")
 public class Args4jUsageMojo extends AbstractMojo {
 
     /**
      * Mode. 'TXT' 'XML' or 'HTML'
-     * @parameter default-value="TXT"
-     * @required
      */
+	@Parameter(defaultValue = "TXT", required = true)
     private String mode;
 
     /**
      * Location of the source files.
-     * @parameter expression="${basedir}/src/main/java"
-     * @required
      */
+	@Parameter(defaultValue = "${basedir}/src/main/java", required = true)
     private String sourceDir;
 
     /**
      * directory where the the usage are generated
-     * @parameter expression="${project.build.directory}/args4j"
-     * @required
      */
+	@Parameter(defaultValue = "${project.build.directory}/args4j", required = true)
     protected String args4jBuildDirPath;
 
     /**
-     * @parameter
+     * Source files to analyze.
      */
+	@Parameter
     private List<String> sourceFiles;
 
     private File jar;

--- a/args4j-tools/pom.xml
+++ b/args4j-tools/pom.xml
@@ -62,6 +62,17 @@
                   <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
+              
+              <!-- Ecluded duplicate resources -->
+              <filters>
+                <filter>
+                  <artifact>args4j:args4j</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>              
             </configuration>
           </execution>
         </executions>

--- a/args4j/src/org/kohsuke/args4j/Config.java
+++ b/args4j/src/org/kohsuke/args4j/Config.java
@@ -67,7 +67,7 @@ public class Config {
 	/**
 	 * Parses a XML file and returns a Config object holding the information.
 	 * @param xml source of the xml data
-	 * @return
+	 * @return The parsed configuration.
 	 * @throws IOException
 	 * @throws SAXException
 	 */

--- a/args4j/src/org/kohsuke/args4j/spi/ConfigElement.java
+++ b/args4j/src/org/kohsuke/args4j/spi/ConfigElement.java
@@ -18,7 +18,7 @@ public class ConfigElement {
 	public boolean hidden = false;
 	/**
 	 * Ensures that only a field XOR a method is set.
-	 * @return
+	 * @return Whether this element has invalid settings.
 	 */
 	public boolean isInvalid() {
 		return field == null && method == null || field != null && method != null;

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,49 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.0</version>
         </plugin>
+
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+        	<groupId>org.eclipse.m2e</groupId>
+        	<artifactId>lifecycle-mapping</artifactId>
+        	<version>1.0.0</version>
+        	<configuration>
+        		<lifecycleMappingMetadata>
+        			<pluginExecutions>
+        				<pluginExecution>
+        					<pluginExecutionFilter>
+        						<groupId>
+        							org.apache.maven.plugins
+        						</groupId>
+        						<artifactId>
+        							maven-plugin-plugin
+        						</artifactId>
+        						<versionRange>[3.2,)</versionRange>
+        						<goals>
+        							<goal>descriptor</goal>
+        						</goals>
+        					</pluginExecutionFilter>
+        					<action>
+        						<ignore></ignore>
+        					</action>
+        				</pluginExecution>
+        				<pluginExecution>
+        					<pluginExecutionFilter>
+        						<groupId>org.codehaus.gmaven</groupId>
+        						<artifactId>gmaven-plugin</artifactId>
+        						<versionRange>[1.4,)</versionRange>
+        						<goals>
+        							<goal>testCompile</goal>
+        						</goals>
+        					</pluginExecutionFilter>
+        					<action>
+        						<ignore></ignore>
+        					</action>
+        				</pluginExecution>
+        			</pluginExecutions>
+        		</lifecycleMappingMetadata>
+        	</configuration>
+        </plugin>
       </plugins>
     </pluginManagement>  
   

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,13 @@
             <compilerArgument>-proc:none</compilerArgument>
           </configuration>
         </plugin>
+
+		<plugin>
+		    <groupId>org.apache.maven.plugins</groupId>
+		    <artifactId>maven-resources-plugin</artifactId>
+		    <version>3.3.0</version>
+		</plugin>		
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke</groupId>
     <artifactId>pom</artifactId>
-    <version>14</version>
+    <version>21</version>
   </parent>
 
   <groupId>args4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,10 +120,11 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.9</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kohsuke.${pom.artifactId}</Bundle-SymbolicName>
+            <Bundle-SymbolicName>org.kohsuke.${project.artifactId}</Bundle-SymbolicName>
             <_includeresource>${basedir}/../LICENSE</_includeresource>
             <_sources>true</_sources>
           </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,18 @@
           </configuration>
         </plugin>
 
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.2.1</version>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.6.3</version>
+        </plugin>
+
 		<plugin>
 		    <groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-resources-plugin</artifactId>
@@ -163,6 +175,31 @@
           <target>1.${java.level}</target>
          </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+            <execution>
+                <goals>
+                    <goal>jar</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+            <execution>
+                <goals>
+                    <goal>jar-no-fork</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,11 +191,9 @@
         <version>2.9</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.6.3</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
Hi @kohsuke,

I cleaned up the build process, fixed warnings reported during the build and especially ensured that javadoc-jar and sources-jar artifacts are created during the build. This is a requirement for Maven-Central deployment nowadays (see 
https://maven.apache.org/repository/guide-central-repository-upload.html).

With these changes, hopefully you should be able to deploy an updated version to Maven-Central. However, to do so I would recommend to reset the version to `2.34-SNAPSHOT` and delete the failed tags `args4j-site-2.34` and `args4j-site-2.35` before to prevent gaps in the version numbers deployed to Maven-Central.
